### PR TITLE
Improve progress history UX

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -39,6 +39,17 @@ def get_all_analysis_results() -> list:
     conn.close()
     return [dict(row) for row in rows]
 
+def get_analysis_by_id(analysis_id: int) -> Dict[str, Any] | None:
+    """Obtiene un único análisis por su ID."""
+    conn = get_db_connection()
+    cursor = conn.execute(
+        "SELECT * FROM analysis_results WHERE id = ?",
+        (analysis_id,)
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
 def save_analysis_results(results: Dict[str, Any], gui_settings: Dict[str, Any]) -> int | None:
     """Guarda los resultados de un análisis.
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -125,6 +125,8 @@ class MainWindow(QMainWindow):
         self.stack.setCurrentIndex(index)
         for i, btn in enumerate(getattr(self, "nav_buttons", [])):
             btn.setChecked(i == index)
+        if index == self.stack.indexOf(self.progress_page):
+            self.progress_page.refresh_analysis_list()
         w = self.stack.currentWidget()
         w.update()
         w.repaint()

--- a/src/gui/pages/progress_page.py
+++ b/src/gui/pages/progress_page.py
@@ -1,17 +1,35 @@
 from typing import Dict, Any
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+)
+from PyQt5.QtCore import Qt
+import pandas as pd
+from datetime import datetime
+import logging
 
+from ... import database
 from ..widgets.results_panel import ResultsPanel
 
 
 class ProgressPage(QWidget):
-    """Página que muestra los resultados del análisis."""
+    """Página que muestra el historial de análisis guardados."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        layout = QVBoxLayout(self)
+        layout = QHBoxLayout(self)
+
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget, 1)
+
         self.results_panel = ResultsPanel(self)
-        layout.addWidget(self.results_panel)
+        layout.addWidget(self.results_panel, 2)
+
+        self.list_widget.itemClicked.connect(self.on_analysis_selected)
+
+        self.refresh_analysis_list()
 
     def clear_results(self) -> None:
         self.results_panel.clear_results()
@@ -22,3 +40,47 @@ class ProgressPage(QWidget):
     def set_theme(self, is_dark: bool) -> None:
         self.results_panel.plot_widget.set_theme(is_dark)
 
+    def refresh_analysis_list(self) -> None:
+        """Carga de la base de datos la lista de análisis."""
+        self.list_widget.clear()
+        for row in database.get_all_analysis_results():
+            try:
+                ts = datetime.fromisoformat(row["timestamp"])
+                formatted = ts.strftime("%d %b %Y - %H:%M")
+            except Exception:
+                formatted = row["timestamp"]
+            item_text = f"{row['exercise_name'].title()} - {formatted}"
+            item = QListWidgetItem(item_text)
+            item.setData(Qt.UserRole, row['id'])
+            self.list_widget.addItem(item)
+
+        if self.list_widget.count() == 0:
+            self.results_panel.show_empty_state()
+        else:
+            self.list_widget.setCurrentRow(0)
+            first_item = self.list_widget.item(0)
+            if first_item:
+                self.on_analysis_selected(first_item)
+
+    def on_analysis_selected(self, item: QListWidgetItem) -> None:
+        analysis_id = item.data(Qt.UserRole)
+        row = database.get_analysis_by_id(int(analysis_id))
+        if not row:
+            return
+        metrics_json = row.get("metrics_df_json")
+        df = None
+        if metrics_json:
+            try:
+                df = pd.read_json(metrics_json, orient="split")
+            except ValueError as e:
+                logging.error("Error parsing JSON for analysis %s: %s", analysis_id, e)
+                self.results_panel.clear_results()
+                self.results_panel.status_label.setText("Datos corruptos para este análisis.")
+                return
+        full_results = {
+            "repeticiones_contadas": row.get("rep_count"),
+            "debug_video_path": row.get("video_path"),
+            "dataframe_metricas": df,
+            "exercise": row.get("exercise_name"),
+        }
+        self.results_panel.update_results(full_results)

--- a/src/gui/widgets/results_panel.py
+++ b/src/gui/widgets/results_panel.py
@@ -164,7 +164,14 @@ class ResultsPanel(QWidget):
             self.video_player.media_player.positionChanged.disconnect(self.on_video_position_changed)
         except TypeError:
             pass
-        
+
         self.rep_counter.setText("0"); self.status_label.setText("Listo para analizar")
         self.plot_widget.clear_plots(); self.fault_list.clear()
         self.video_player.clear_media(); self.visibility_group.hide()
+
+    def show_empty_state(self) -> None:
+        """Muestra un mensaje cuando no hay análisis guardados."""
+        self.clear_results()
+        self.status_label.setText(
+            "No hay análisis guardados. ¡Analiza tu primer vídeo para empezar!"
+        )


### PR DESCRIPTION
## Summary
- format timestamps in progress list and auto-load latest
- handle empty history with `ResultsPanel.show_empty_state`
- guard against invalid JSON in stored metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c2fe14b28832082b166b272658bde