### PR TITLE
Add persistent training plans

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -127,6 +127,8 @@ class MainWindow(QMainWindow):
             btn.setChecked(i == index)
         if index == self.stack.indexOf(self.progress_page):
             self.progress_page.refresh_analysis_list()
+        if index == self.stack.indexOf(self.dashboard_page):
+            self.dashboard_page.refresh_dashboard()
         w = self.stack.currentWidget()
         w.update()
         w.repaint()

--- a/src/gui/pages/dashboard_page.py
+++ b/src/gui/pages/dashboard_page.py
@@ -1,22 +1,61 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
-from PyQt5.QtGui import QFont
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QGroupBox
+from datetime import datetime
+
+from ... import database
 
 
 class DashboardPage(QWidget):
-    """Página de bienvenida."""
+    """Página principal que resume el estado de la aplicación."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
         layout = QVBoxLayout(self)
-        label = QLabel("Bienvenido a Gym Performance Analyzer")
-        font = QFont()
-        font.setPointSize(16)
-        font.setBold(True)
-        label.setFont(font)
-        label.setAlignment(Qt.AlignCenter)
-        layout.addStretch(1)
-        layout.addWidget(label)
+        layout.setSpacing(20)
+
+        self.analysis_card, self.analysis_label = self._create_summary_card(
+            "Último Análisis", "No hay análisis guardados."
+        )
+        self.plan_card, self.plan_label = self._create_summary_card(
+            "Plan Activo", "No hay plan activo."
+        )
+
+        layout.addWidget(self.analysis_card)
+        layout.addWidget(self.plan_card)
         layout.addStretch(1)
 
+    def _create_summary_card(self, title: str, content: str):
+        box = QGroupBox(title)
+        vbox = QVBoxLayout(box)
+        label = QLabel(content)
+        label.setWordWrap(True)
+        vbox.addWidget(label)
+        return box, label
+
+    def refresh_dashboard(self) -> None:
+        """Carga los datos más recientes para mostrar en el dashboard."""
+        row = database.get_latest_analysis()
+        if row:
+            try:
+                ts = datetime.fromisoformat(row["timestamp"]).strftime("%d %b %Y - %H:%M")
+            except Exception:
+                ts = row["timestamp"]
+            text = f"{row['exercise_name'].title()} - Reps: {row.get('rep_count', 'N/A')} ({ts})"
+        else:
+            text = "No hay análisis guardados."
+        self.analysis_label.setText(text)
+
+        plan_id = database.get_app_state("active_plan_id")
+        if plan_id:
+            plan = database.get_plan_by_id(int(plan_id))
+            if plan:
+                try:
+                    pt = datetime.fromisoformat(plan["timestamp"]).strftime("%d %b %Y - %H:%M")
+                except Exception:
+                    pt = plan["timestamp"]
+                plan_text = f"{plan['title']} ({pt})"
+            else:
+                plan_text = "Plan no encontrado."
+        else:
+            plan_text = "No hay plan activo."
+        self.plan_label.setText(plan_text)


### PR DESCRIPTION
## Summary
- create `training_plans` table and helpers in `database.py`
- redesign Plans page to show saved plans and allow storing new ones
- add `app_state` table and dashboard with last analysis/active plan
- enable selecting an active plan

## Testing
- `python -m py_compile src/database.py src/gui/pages/plans_page.py src/gui/pages/dashboard_page.py src/gui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d05613fd0832087bfa089364b5169