### PR TITLE
Fix circular import in GUI plans page

### DIFF
--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -61,7 +61,7 @@ def run_app():
 
     app = QApplication(sys.argv)
     # No forzamos aquí el tema: _apply_theme del MainWindow leerá el checkbox
-    window = MainWindow(project_root=PROJECT_ROOT)
+    window = MainWindow(project_root=PROJECT_ROOT, translator=translator)
     window.show()
     sys.exit(app.exec_())
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -41,15 +41,17 @@ class MainWindow(QMainWindow):
     Ventana principal de la aplicación. Orquesta todos los widgets y la interacción
     con el pipeline de análisis. Gestiona el estado de la GUI y las preferencias del usuario.
     """
-    def __init__(self, project_root: str, parent=None):
+    def __init__(self, project_root: str, translator, parent=None):
         """
         Constructor de la ventana principal.
-        
+
         Args:
             project_root (str): Ruta raíz del proyecto para localizar recursos como hojas de estilo.
+            translator: Instancia de ``Translator`` para localizar la interfaz.
         """
         super().__init__(parent)
         self.project_root = project_root
+        self.translator = translator
         self.video_path: Optional[str] = None
         self.gui_settings: Dict[str, Any] = {}
         
@@ -91,7 +93,7 @@ class MainWindow(QMainWindow):
         )
         self.progress_page = ProgressPage()
         self.results_panel = self.progress_page.results_panel
-        self.plans_page = PlansPage()
+        self.plans_page = PlansPage(self.translator)
         self.settings_page = SettingsPage(settings.exercises, self._apply_theme)
 
         self.stack.addWidget(self.dashboard_page)

--- a/src/gui/pages/plans_page.py
+++ b/src/gui/pages/plans_page.py
@@ -21,14 +21,17 @@ from datetime import datetime
 
 from ...services.plan_generator import PlanGeneratorWorker
 from ... import database
-from ..main import translator
+
+# The translator instance is provided by the MainWindow when constructing
+# this page to avoid circular imports with src.gui.main
 
 
 class PlansPage(QWidget):
     """Página para generar planes de entrenamiento personalizados."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, translator, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.translator = translator
 
         main_layout = QHBoxLayout(self)
 
@@ -47,7 +50,7 @@ class PlansPage(QWidget):
                 "Resistencia",
             ]
         )
-        form_layout.addRow(translator.tr("main_goal"), self.objetivo_cb)
+        form_layout.addRow(self.translator.tr("main_goal"), self.objetivo_cb)
 
         self.dias_sb = QSpinBox()
         self.dias_sb.setRange(1, 7)
@@ -91,17 +94,17 @@ class PlansPage(QWidget):
 
         right_layout.addWidget(self.results_stack, 1)
 
-        self.save_plan_btn = QPushButton(translator.tr("save_plan"))
+        self.save_plan_btn = QPushButton(self.translator.tr("save_plan"))
         self.save_plan_btn.setEnabled(False)
         self.save_plan_btn.setToolTip("Guardar el plan mostrado en tu historial")
         right_layout.addWidget(self.save_plan_btn)
 
         self.set_active_btn = QPushButton("Establecer como Plan Activo")
         self.set_active_btn.setEnabled(False)
-        self.set_active_btn.setToolTip(translator.tr("active_plan_tooltip"))
+        self.set_active_btn.setToolTip(self.translator.tr("active_plan_tooltip"))
         right_layout.addWidget(self.set_active_btn)
 
-        self.generate_btn = QPushButton(translator.tr("generate_plan"))
+        self.generate_btn = QPushButton(self.translator.tr("generate_plan"))
         self.generate_btn.setToolTip("Generar un nuevo plan de entrenamiento con IA")
         self.generate_btn.clicked.connect(self.on_generate_plan_clicked)
         left_layout.addWidget(self.generate_btn)


### PR DESCRIPTION
## Summary
- avoid circular imports by injecting `translator` into `PlansPage`
- update `MainWindow` to forward the translator instance
- adjust invocation in `run_app`

## Testing
- `pytest -q`
- `python -m src.gui.main --help` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_685d1f4b22688320963cd92a56e7bfaa