### PR TITLE
Implement dashboard redesign with reusable cards

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -207,3 +207,28 @@ def get_latest_analysis() -> Dict[str, Any] | None:
     row = cursor.fetchone()
     conn.close()
     return dict(row) if row else None
+
+
+def get_total_analysis_count() -> int:
+    """Devuelve el número total de análisis almacenados."""
+    conn = get_db_connection()
+    cursor = conn.execute("SELECT COUNT(id) FROM analysis_results")
+    count = cursor.fetchone()[0]
+    conn.close()
+    try:
+        return int(count)
+    except (TypeError, ValueError):  # pragma: no cover - fallback
+        return 0
+
+
+def get_recent_reps_by_exercise(exercise_name: str, limit: int = 10) -> list:
+    """Obtiene los últimos registros de un ejercicio para el gráfico principal."""
+    conn = get_db_connection()
+    cursor = conn.execute(
+        "SELECT timestamp, rep_count FROM analysis_results WHERE exercise_name = ? ORDER BY timestamp DESC LIMIT ?",
+        (exercise_name, limit),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    dict_rows = [dict(row) for row in rows]
+    return list(reversed(dict_rows))

--- a/src/gui/pages/dashboard_page.py
+++ b/src/gui/pages/dashboard_page.py
@@ -1,5 +1,8 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QGroupBox
+from PyQt5.QtWidgets import QWidget, QGridLayout, QLabel, QVBoxLayout
 from datetime import datetime
+
+from ..widgets.dashboard_card import DashboardCard
+import pyqtgraph as pg
 
 from ... import database
 
@@ -10,27 +13,58 @@ class DashboardPage(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        layout = QVBoxLayout(self)
-        layout.setSpacing(20)
+        layout = QGridLayout(self)
+        layout.setSpacing(10)
+        self.grid_layout = layout
 
-        self.analysis_card, self.analysis_label = self._create_summary_card(
-            "Último Análisis", "No hay análisis guardados."
-        )
-        self.plan_card, self.plan_label = self._create_summary_card(
-            "Plan Activo", "No hay plan activo."
-        )
+        # KPI Cards
+        self.kpi1_card = DashboardCard("Último Análisis")
+        self.kpi1_value = QLabel("N/A")
+        self.kpi1_value.setObjectName("kpiValue")
+        self.kpi1_sub = QLabel("")
+        self.kpi1_sub.setObjectName("kpiSubtitle")
+        kpi1_layout = QVBoxLayout(); kpi1_layout.addWidget(self.kpi1_value); kpi1_layout.addWidget(self.kpi1_sub)
+        kpi1_widget = QWidget(); kpi1_widget.setLayout(kpi1_layout)
+        self.kpi1_card.setContent(kpi1_widget)
 
-        layout.addWidget(self.analysis_card)
-        layout.addWidget(self.plan_card)
-        layout.addStretch(1)
+        self.kpi2_card = DashboardCard("Métrica Clave")
+        self.kpi2_value = QLabel("N/A")
+        self.kpi2_value.setObjectName("kpiValue")
+        self.kpi2_sub = QLabel("")
+        self.kpi2_sub.setObjectName("kpiSubtitle")
+        kpi2_layout = QVBoxLayout(); kpi2_layout.addWidget(self.kpi2_value); kpi2_layout.addWidget(self.kpi2_sub)
+        kpi2_widget = QWidget(); kpi2_widget.setLayout(kpi2_layout)
+        self.kpi2_card.setContent(kpi2_widget)
 
-    def _create_summary_card(self, title: str, content: str):
-        box = QGroupBox(title)
-        vbox = QVBoxLayout(box)
-        label = QLabel(content)
-        label.setWordWrap(True)
-        vbox.addWidget(label)
-        return box, label
+        self.kpi3_card = DashboardCard("Plan Activo")
+        self.kpi3_value = QLabel("N/A")
+        self.kpi3_value.setObjectName("kpiValue")
+        self.kpi3_sub = QLabel("")
+        self.kpi3_sub.setObjectName("kpiSubtitle")
+        kpi3_layout = QVBoxLayout(); kpi3_layout.addWidget(self.kpi3_value); kpi3_layout.addWidget(self.kpi3_sub)
+        kpi3_widget = QWidget(); kpi3_widget.setLayout(kpi3_layout)
+        self.kpi3_card.setContent(kpi3_widget)
+
+        self.kpi4_card = DashboardCard("Sesiones Totales")
+        self.kpi4_value = QLabel("0")
+        self.kpi4_value.setObjectName("kpiValue")
+        self.kpi4_sub = QLabel("")
+        self.kpi4_sub.setObjectName("kpiSubtitle")
+        kpi4_layout = QVBoxLayout(); kpi4_layout.addWidget(self.kpi4_value); kpi4_layout.addWidget(self.kpi4_sub)
+        kpi4_widget = QWidget(); kpi4_widget.setLayout(kpi4_layout)
+        self.kpi4_card.setContent(kpi4_widget)
+
+        layout.addWidget(self.kpi1_card, 0, 0)
+        layout.addWidget(self.kpi2_card, 0, 1)
+        layout.addWidget(self.kpi3_card, 0, 2)
+        layout.addWidget(self.kpi4_card, 0, 3)
+
+        # Chart Card
+        self.chart_card = DashboardCard("Progreso")
+        self.plot_widget = pg.PlotWidget()
+        self.chart_card.setContent(self.plot_widget)
+        layout.addWidget(self.chart_card, 1, 0, 1, 4)
+
 
     def refresh_dashboard(self) -> None:
         """Carga los datos más recientes para mostrar en el dashboard."""
@@ -40,22 +74,55 @@ class DashboardPage(QWidget):
                 ts = datetime.fromisoformat(row["timestamp"]).strftime("%d %b %Y - %H:%M")
             except Exception:
                 ts = row["timestamp"]
-            text = f"{row['exercise_name'].title()} - Reps: {row.get('rep_count', 'N/A')} ({ts})"
+            self.kpi1_value.setText(row["exercise_name"].title())
+            self.kpi1_sub.setText(f"Reps: {row.get('rep_count', 'N/A')} ({ts})")
+            val = row.get("key_metric_avg")
+            self.kpi2_value.setText(f"{val:.2f}" if isinstance(val, (int, float)) else "N/A")
+            self.kpi2_sub.setText("Métrica Clave promedio")
         else:
-            text = "No hay análisis guardados."
-        self.analysis_label.setText(text)
+            self.kpi1_value.setText("N/A")
+            self.kpi1_sub.setText("No hay análisis guardados.")
+            self.kpi2_value.setText("N/A")
+            self.kpi2_sub.setText("")
 
         plan_id = database.get_app_state("active_plan_id")
         if plan_id:
             plan = database.get_plan_by_id(int(plan_id))
             if plan:
+                self.kpi3_value.setText(plan["title"])
                 try:
                     pt = datetime.fromisoformat(plan["timestamp"]).strftime("%d %b %Y - %H:%M")
                 except Exception:
                     pt = plan["timestamp"]
-                plan_text = f"{plan['title']} ({pt})"
+                self.kpi3_sub.setText(pt)
             else:
-                plan_text = "Plan no encontrado."
+                self.kpi3_value.setText("N/A")
+                self.kpi3_sub.setText("Plan no encontrado")
         else:
-            plan_text = "No hay plan activo."
-        self.plan_label.setText(plan_text)
+            self.kpi3_value.setText("N/A")
+            self.kpi3_sub.setText("No hay plan activo")
+
+        total = database.get_total_analysis_count()
+        self.kpi4_value.setText(str(total))
+        self.kpi4_sub.setText("Análisis guardados")
+
+        exercise_for_chart = row["exercise_name"] if row else None
+        if exercise_for_chart:
+            rows = database.get_recent_reps_by_exercise(exercise_for_chart)
+        else:
+            rows = []
+
+        self.plot_widget.clear()
+        if rows:
+            x = []
+            y = []
+            for r in rows:
+                try:
+                    dt = datetime.fromisoformat(r["timestamp"])
+                except Exception:
+                    continue
+                x.append(dt.timestamp())
+                y.append(int(r.get("rep_count", 0)))
+            pen = pg.mkPen('b', width=2)
+            self.plot_widget.plot(x=x, y=y, pen=pen, symbol='o', symbolBrush='b')
+

--- a/src/gui/widgets/dashboard_card.py
+++ b/src/gui/widgets/dashboard_card.py
@@ -1,0 +1,31 @@
+from PyQt5.QtWidgets import QGroupBox, QVBoxLayout, QWidget
+from typing import Optional
+
+try:
+    import qtawesome as qta  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    qta = None
+
+class DashboardCard(QGroupBox):
+    """Card container for dashboard KPI and charts."""
+
+    def __init__(self, title: str, icon_name: Optional[str] = None, parent: Optional[QWidget] = None) -> None:
+        # Prepend icon text if qtawesome is available
+        if icon_name and qta is not None:
+            try:
+                icon_txt = qta.icon(icon_name).text()
+                title = f"{icon_txt}  {title}"
+            except Exception:
+                pass
+        super().__init__(title, parent)
+        self.setObjectName("DashboardCard")
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(10, 20, 10, 10)
+
+    def setContent(self, widget: QWidget) -> None:
+        """Replace current content with the provided widget."""
+        while self._layout.count() > 0:
+            item = self._layout.takeAt(0)
+            if item.widget():
+                item.widget().setParent(None)
+        self._layout.addWidget(widget)

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -55,3 +55,31 @@ QListWidget::item {
 QListWidget::item:hover {
   background-color: #3c3c3c;
 }
+/* Estilo base para todas las tarjetas del dashboard */
+QGroupBox#DashboardCard {
+    background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */
+    border-radius: 8px;
+    border: 1px solid #4A5568;
+}
+
+/* Estilo para los títulos de las tarjetas */
+QGroupBox#DashboardCard::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 5px 10px;
+    color: #A0AEC0;
+    font-size: 10pt;
+    font-weight: bold;
+}
+
+/* Clases específicas para los valores principales de las KPI cards */
+QLabel#kpiValue {
+    font-size: 24pt;
+    font-weight: bold;
+    color: #FFFFFF;
+}
+
+QLabel#kpiSubtitle {
+    font-size: 9pt;
+    color: #718096;
+}

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -51,3 +51,31 @@ QListWidget::item {
 QListWidget::item:hover {
   background-color: #f0f0f0;
 }
+/* Estilo base para todas las tarjetas del dashboard */
+QGroupBox#DashboardCard {
+    background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */
+    border-radius: 8px;
+    border: 1px solid #4A5568;
+}
+
+/* Estilo para los títulos de las tarjetas */
+QGroupBox#DashboardCard::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 5px 10px;
+    color: #A0AEC0;
+    font-size: 10pt;
+    font-weight: bold;
+}
+
+/* Clases específicas para los valores principales de las KPI cards */
+QLabel#kpiValue {
+    font-size: 24pt;
+    font-weight: bold;
+    color: #FFFFFF;
+}
+
+QLabel#kpiSubtitle {
+    font-size: 9pt;
+    color: #718096;
+}


### PR DESCRIPTION
## Summary
- add new reusable `DashboardCard` widget
- refactor `DashboardPage` to use a grid layout with KPI cards and a chart
- extend database helpers to provide counts and recent reps
- update dashboard refresh logic
- style dashboard cards in QSS themes

## Testing
- `python -m py_compile src/gui/widgets/dashboard_card.py src/gui/pages/dashboard_page.py src/database.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d2204032883209a0ee1fa55f35391