### PR TITLE
Add exercises library with detail page

### DIFF
--- a/src/gui/pages/__init__.py
+++ b/src/gui/pages/__init__.py
@@ -3,6 +3,8 @@ from .analysis_page import AnalysisPage
 from .plans_page import PlansPage
 from .progress_page import ProgressPage
 from .settings_page import SettingsPage
+from .exercises_page import ExercisesPage
+from .exercise_detail_page import ExerciseDetailPage
 
 __all__ = [
     "DashboardPage",
@@ -10,5 +12,7 @@ __all__ = [
     "PlansPage",
     "ProgressPage",
     "SettingsPage",
+    "ExercisesPage",
+    "ExerciseDetailPage",
 ]
 

--- a/src/gui/pages/exercise_detail_page.py
+++ b/src/gui/pages/exercise_detail_page.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+import os
+
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTabWidget,
+    QTextEdit,
+    QLabel,
+    QFormLayout,
+    QSpinBox,
+    QDoubleSpinBox,
+    QLineEdit,
+    QPushButton,
+)
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtCore import Qt
+import pyqtgraph as pg
+
+from ... import database
+from .analysis_page import AnalysisPage
+
+
+class ExerciseDetailPage(QWidget):
+    """Detalle de un ejercicio con varias pestañas."""
+
+    def __init__(
+        self,
+        on_video_selected,
+        on_rotation_requested,
+        on_open_file_dialog,
+        on_start_analysis,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        main_layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        main_layout.addWidget(self.tabs)
+
+        # Tab Descripción
+        desc_widget = QWidget()
+        desc_layout = QVBoxLayout(desc_widget)
+        self.description_edit = QTextEdit()
+        self.description_edit.setReadOnly(True)
+        desc_layout.addWidget(self.description_edit)
+        self.tabs.addTab(desc_widget, "Ejercicio")
+
+        # Tab Músculos
+        muscles_widget = QWidget()
+        muscles_layout = QVBoxLayout(muscles_widget)
+        self.image_label = QLabel()
+        self.image_label.setAlignment(Qt.AlignCenter)
+        muscles_layout.addWidget(self.image_label)
+        self.tabs.addTab(muscles_widget, "Músculos")
+
+        # Tab Estadísticas
+        stats_widget = QWidget()
+        stats_layout = QVBoxLayout(stats_widget)
+        form = QFormLayout()
+        self.reps_spin = QSpinBox()
+        self.reps_spin.setRange(0, 1000)
+        self.weight_spin = QDoubleSpinBox()
+        self.weight_spin.setRange(0, 1000)
+        self.weight_spin.setDecimals(2)
+        self.notes_edit = QLineEdit()
+        self.save_log_btn = QPushButton("Guardar")
+        form.addRow("Reps", self.reps_spin)
+        form.addRow("Peso", self.weight_spin)
+        form.addRow("Notas", self.notes_edit)
+        form.addRow(self.save_log_btn)
+        stats_layout.addLayout(form)
+        self.progress_plot = pg.PlotWidget()
+        stats_layout.addWidget(self.progress_plot, 1)
+        self.tabs.addTab(stats_widget, "Estadísticas")
+
+        # Tab Análisis de Técnica
+        analysis_container = QWidget()
+        analysis_layout = QVBoxLayout(analysis_container)
+        self.analysis_page = AnalysisPage(
+            on_video_selected,
+            on_rotation_requested,
+            on_open_file_dialog,
+            on_start_analysis,
+        )
+        analysis_layout.addWidget(self.analysis_page)
+        self.tabs.addTab(analysis_container, "Análisis de Técnica")
+
+        self.exercise_id: int | None = None
+        self.save_log_btn.clicked.connect(self.on_save_log)
+
+    def load_exercise(self, exercise_id: int) -> None:
+        """Carga la información del ejercicio y actualiza las pestañas."""
+        self.exercise_id = exercise_id
+        row = database.get_exercise_by_id(exercise_id)
+        if not row:
+            return
+        self.description_edit.setMarkdown(row.get("description_md", ""))
+        img_path = row.get("image_url")
+        if img_path and os.path.exists(img_path):
+            self.image_label.setPixmap(QPixmap(img_path))
+        else:
+            self.image_label.clear()
+        self._refresh_logs()
+
+    def on_save_log(self) -> None:
+        if self.exercise_id is None:
+            return
+        timestamp = datetime.utcnow().isoformat()
+        reps = int(self.reps_spin.value())
+        weight = float(self.weight_spin.value())
+        notes = self.notes_edit.text().strip() or None
+        database.add_manual_log(timestamp, self.exercise_id, reps, weight, notes)
+        self.reps_spin.setValue(0)
+        self.weight_spin.setValue(0)
+        self.notes_edit.clear()
+        self._refresh_logs()
+
+    def _refresh_logs(self) -> None:
+        if self.exercise_id is None:
+            return
+        rows = database.get_logs_for_exercise(self.exercise_id)
+        self.progress_plot.clear()
+        if not rows:
+            return
+        x = []
+        y = []
+        for r in rows:
+            try:
+                dt = datetime.fromisoformat(r["timestamp"])
+            except Exception:
+                continue
+            x.append(dt.timestamp())
+            y.append(float(r.get("weight", 0)))
+        pen = pg.mkPen('b', width=2)
+        self.progress_plot.plot(x=x, y=y, pen=pen, symbol='o', symbolBrush='b')
+

--- a/src/gui/pages/exercises_page.py
+++ b/src/gui/pages/exercises_page.py
@@ -1,0 +1,52 @@
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QListWidget, QListWidgetItem
+from PyQt5.QtCore import Qt, pyqtSignal
+
+from ... import database
+
+
+class ExercisesPage(QWidget):
+    """Biblioteca de ejercicios."""
+
+    exercise_selected = pyqtSignal(int)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QHBoxLayout(self)
+
+        self.group_list = QListWidget()
+        layout.addWidget(self.group_list)
+
+        self.exercise_list = QListWidget()
+        layout.addWidget(self.exercise_list, 1)
+
+        self.group_list.itemClicked.connect(self.on_group_selected)
+        self.exercise_list.itemDoubleClicked.connect(self.on_exercise_double_clicked)
+
+        self.refresh_groups()
+
+    def refresh_groups(self) -> None:
+        """Carga los grupos musculares y muestra los ejercicios del primero."""
+        self.group_list.clear()
+        groups = database.get_all_muscle_groups()
+        self.group_list.addItem("Todos")
+        for g in groups:
+            self.group_list.addItem(g)
+        self.group_list.setCurrentRow(0)
+        if self.group_list.count() > 0:
+            self.on_group_selected(self.group_list.item(0))
+
+    def on_group_selected(self, item: QListWidgetItem) -> None:
+        group = item.text()
+        self.exercise_list.clear()
+        exercises = database.get_exercises_by_group(group)
+        for ex in exercises:
+            it = QListWidgetItem(ex["name"])
+            it.setData(Qt.UserRole, ex["id"])
+            self.exercise_list.addItem(it)
+
+    def on_exercise_double_clicked(self, item: QListWidgetItem) -> None:
+        ex_id = item.data(Qt.UserRole)
+        if ex_id is not None:
+            self.exercise_selected.emit(int(ex_id))
+


### PR DESCRIPTION
## Summary
- create new tables `exercises` and `manual_logs`
- add helpers for exercises and logging
- populate example exercises on first run
- add `ExercisesPage` and `ExerciseDetailPage`
- integrate new pages into `MainWindow`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d2bdddf608320961323100dc8d2e7