### PR TITLE
Implement exercises library

### DIFF
--- a/src/gui/pages/exercises_page.py
+++ b/src/gui/pages/exercises_page.py
@@ -1,4 +1,10 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QListWidget, QListWidgetItem
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QComboBox,
+    QListWidget,
+    QListWidgetItem,
+)
 from PyQt5.QtCore import Qt, pyqtSignal
 
 from ... import database
@@ -12,32 +18,35 @@ class ExercisesPage(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        layout = QHBoxLayout(self)
+        layout = QVBoxLayout(self)
 
-        self.group_list = QListWidget()
-        layout.addWidget(self.group_list)
+        self.group_combo = QComboBox()
+        layout.addWidget(self.group_combo)
 
         self.exercise_list = QListWidget()
         layout.addWidget(self.exercise_list, 1)
 
-        self.group_list.itemClicked.connect(self.on_group_selected)
+        self.group_combo.currentTextChanged.connect(self.on_group_changed)
         self.exercise_list.itemDoubleClicked.connect(self.on_exercise_double_clicked)
 
         self.refresh_groups()
 
     def refresh_groups(self) -> None:
-        """Carga los grupos musculares y muestra los ejercicios del primero."""
-        self.group_list.clear()
+        """Carga la lista de grupos musculares en el combo."""
+        self.group_combo.clear()
         groups = database.get_all_muscle_groups()
-        self.group_list.addItem("Todos")
+        self.group_combo.addItem("Todos")
         for g in groups:
-            self.group_list.addItem(g)
-        self.group_list.setCurrentRow(0)
-        if self.group_list.count() > 0:
-            self.on_group_selected(self.group_list.item(0))
+            self.group_combo.addItem(g)
+        if self.group_combo.count() > 0:
+            self.group_combo.setCurrentIndex(0)
+            self.refresh_exercises()
 
-    def on_group_selected(self, item: QListWidgetItem) -> None:
-        group = item.text()
+    def on_group_changed(self, group: str) -> None:
+        self.refresh_exercises()
+
+    def refresh_exercises(self) -> None:
+        group = self.group_combo.currentText()
         self.exercise_list.clear()
         exercises = database.get_exercises_by_group(group)
         for ex in exercises:


### PR DESCRIPTION
## Summary
- refine ExercisesPage layout with combo filter
- new support for exercises and logs in DB
- add exercise navigation slot in main window

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d36ad7ed8832083e2573ca988f86b