### PR TITLE
Implement custom calendar widget

### DIFF
--- a/src/gui/pages/dashboard_page.py
+++ b/src/gui/pages/dashboard_page.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QCalendarWidget,
     QGroupBox,
     QTextEdit,
 )
 from PyQt5.QtCore import QDate
-from PyQt5.QtGui import QTextCharFormat, QColor
+
+from src.gui.widgets.custom_calendar_widget import CustomCalendarWidget
 
 
 class DashboardPage(QWidget):
@@ -19,25 +19,15 @@ class DashboardPage(QWidget):
 
         layout = QVBoxLayout(self)
 
-        self.calendar = QCalendarWidget()
-        self._highlight_today()
+        self.calendar = CustomCalendarWidget()
         layout.addWidget(self.calendar)
 
         self.plan_group = QGroupBox("Plan para Hoy")
         plan_layout = QVBoxLayout(self.plan_group)
         self.plan_text = QTextEdit(readOnly=True)
-        self.plan_text.setPlaceholderText(
-            "No hay entrenamiento planificado para hoy."
-        )
+        self.plan_text.setPlaceholderText("No hay entrenamiento planificado para hoy.")
         plan_layout.addWidget(self.plan_text)
         layout.addWidget(self.plan_group)
-
-    def _highlight_today(self) -> None:
-        today = QDate.currentDate()
-        fmt = QTextCharFormat()
-        fmt.setBackground(QColor("#3366ff"))
-        fmt.setForeground(QColor("white"))
-        self.calendar.setDateTextFormat(today, fmt)
 
     def refresh_dashboard(self) -> None:
         """Actualiza el plan del día utilizando un plan de ejemplo."""
@@ -97,4 +87,3 @@ Descanso
             self.plan_text.setMarkdown(plan_text)
         else:
             self.plan_text.setMarkdown("Descanso. No hay entrenamiento para hoy.")
-

--- a/src/gui/widgets/custom_calendar_widget.py
+++ b/src/gui/widgets/custom_calendar_widget.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QGridLayout,
+)
+from PyQt5.QtCore import QDate, Qt
+
+from .day_cell_widget import DayCellWidget
+
+
+class CustomCalendarWidget(QWidget):
+    """Calendario personalizado basado en DayCellWidget."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._current_date = QDate.currentDate()
+
+        main_layout = QVBoxLayout(self)
+
+        # ----- Cabecera de navegación -----
+        header_layout = QHBoxLayout()
+        self.prev_button = QPushButton("<")
+        self.prev_button.setObjectName("calendarNavButton")
+        self.next_button = QPushButton(">")
+        self.next_button.setObjectName("calendarNavButton")
+        self.header_label = QLabel()
+        self.header_label.setObjectName("calendarHeader")
+        self.header_label.setAlignment(Qt.AlignCenter)
+
+        header_layout.addWidget(self.prev_button)
+        header_layout.addStretch()
+        header_layout.addWidget(self.header_label)
+        header_layout.addStretch()
+        header_layout.addWidget(self.next_button)
+        main_layout.addLayout(header_layout)
+
+        # ----- Grid de días -----
+        self.grid_layout = QGridLayout()
+        self.grid_layout.setSpacing(2)
+        main_layout.addLayout(self.grid_layout)
+
+        self.day_cells: list[DayCellWidget] = []
+        for row in range(6):
+            for col in range(7):
+                cell = DayCellWidget()
+                self.grid_layout.addWidget(cell, row, col)
+                self.day_cells.append(cell)
+
+        # Conexiones de navegación
+        self.prev_button.clicked.connect(self._go_prev_month)
+        self.next_button.clicked.connect(self._go_next_month)
+
+        self.populate_month(self._current_date.year(), self._current_date.month())
+
+    # ------------------------------------------------------------------
+    def populate_month(self, year: int, month: int) -> None:
+        """Rellena el calendario con los días del mes especificado."""
+        self._current_date = QDate(year, month, 1)
+        self.header_label.setText(self._current_date.toString("MMMM yyyy"))
+
+        first_day = QDate(year, month, 1)
+        start_day = first_day.dayOfWeek()  # 1=Mon ... 7=Sun
+        days_in_month = first_day.daysInMonth()
+
+        prev_month = first_day.addMonths(-1)
+        days_in_prev = prev_month.daysInMonth()
+
+        today = QDate.currentDate()
+
+        index = 0
+        # Días del mes anterior
+        for i in range(start_day - 1):
+            day_num = days_in_prev - start_day + 2 + i
+            self.day_cells[index].set_day(day_num, False, False)
+            index += 1
+
+        # Días del mes actual
+        for day in range(1, days_in_month + 1):
+            is_today = (
+                day == today.day() and month == today.month() and year == today.year()
+            )
+            self.day_cells[index].set_day(day, is_today, True)
+            index += 1
+
+        # Días del mes siguiente
+        next_day = 1
+        while index < len(self.day_cells):
+            self.day_cells[index].set_day(next_day, False, False)
+            next_day += 1
+            index += 1
+
+    # ------------------------------------------------------------------
+    def _go_prev_month(self) -> None:
+        new_date = self._current_date.addMonths(-1)
+        self.populate_month(new_date.year(), new_date.month())
+
+    def _go_next_month(self) -> None:
+        new_date = self._current_date.addMonths(1)
+        self.populate_month(new_date.year(), new_date.month())

--- a/src/gui/widgets/day_cell_widget.py
+++ b/src/gui/widgets/day_cell_widget.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt5.QtCore import Qt
+
+
+class DayCellWidget(QWidget):
+    """Widget que representa una celda de día en el calendario."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setProperty("isToday", False)
+        self.setProperty("isCurrentMonth", True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setAlignment(Qt.AlignCenter)
+
+        self.day_label = QLabel("", self)
+        self.day_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.day_label)
+
+    def set_day(self, day_number: int, is_today: bool, is_current_month: bool) -> None:
+        """Actualiza la celda con el número de día y su estado."""
+        self.day_label.setText(str(day_number))
+        self.setProperty("isToday", is_today)
+        self.setProperty("isCurrentMonth", is_current_month)
+        # Forzar repintado de estilos QSS
+        self.style().unpolish(self)
+        self.style().polish(self)

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -83,3 +83,46 @@ QLabel#kpiSubtitle {
     font-size: 9pt;
     color: #718096;
 }
+
+/* Contenedor principal del calendario personalizado */
+CustomCalendarWidget {
+    background-color: transparent;
+}
+
+/* Cabecera de navegación (Mes y Año) */
+QLabel#calendarHeader {
+    font-size: 16pt;
+    font-weight: bold;
+    color: #E2E8F0;
+}
+
+/* Botones de navegación del calendario */
+QPushButton#calendarNavButton {
+    background-color: #4A5568;
+    border-radius: 15px;
+    font-size: 14pt;
+    min-width: 30px;
+    max-width: 30px;
+}
+
+/* Celda de un día del calendario */
+DayCellWidget {
+    background-color: transparent;
+    border: none;
+}
+
+DayCellWidget QLabel {
+    font-size: 10pt;
+    font-weight: bold;
+    color: #CBD5E0;
+}
+
+DayCellWidget[isCurrentMonth="false"] QLabel {
+    color: #4A5568;
+}
+
+DayCellWidget[isToday="true"] QLabel {
+    background-color: #3182CE;
+    color: white;
+    border-radius: 13px;
+}

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -79,3 +79,46 @@ QLabel#kpiSubtitle {
     font-size: 9pt;
     color: #718096;
 }
+
+/* Contenedor principal del calendario personalizado */
+CustomCalendarWidget {
+    background-color: transparent;
+}
+
+/* Cabecera de navegación (Mes y Año) */
+QLabel#calendarHeader {
+    font-size: 16pt;
+    font-weight: bold;
+    color: #2D3748;
+}
+
+/* Botones de navegación del calendario */
+QPushButton#calendarNavButton {
+    background-color: #CBD5E0;
+    border-radius: 15px;
+    font-size: 14pt;
+    min-width: 30px;
+    max-width: 30px;
+}
+
+/* Celda de un día del calendario */
+DayCellWidget {
+    background-color: transparent;
+    border: none;
+}
+
+DayCellWidget QLabel {
+    font-size: 10pt;
+    font-weight: bold;
+    color: #4A5568;
+}
+
+DayCellWidget[isCurrentMonth="false"] QLabel {
+    color: #A0AEC0;
+}
+
+DayCellWidget[isToday="true"] QLabel {
+    background-color: #3182CE;
+    color: white;
+    border-radius: 13px;
+}


### PR DESCRIPTION
## Summary
- add `DayCellWidget` and `CustomCalendarWidget`
- update dashboard page to use custom calendar
- apply QSS styles for calendar widgets in both themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d390ae5608320afe6cdf8c25bfaad