### PR TITLE
Improve navigation and calendar widgets

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -75,6 +75,7 @@ class MainWindow(QMainWindow):
         main_layout = QHBoxLayout(container)
 
         nav_widget = QWidget()
+        nav_widget.setObjectName("navPanel")
         self.nav_layout = QVBoxLayout(nav_widget)
         self.nav_layout.setContentsMargins(0, 0, 0, 0)
         self.nav_layout.setSpacing(10)
@@ -109,7 +110,7 @@ class MainWindow(QMainWindow):
         # Botones de navegación
         self.nav_buttons = []
         buttons = [
-            ("fa5s.tachometer-alt", "Dashboard", "Ir a la sección de Dashboard"),
+            ("fa5s.tachometer-alt", "Inicio", "Ir a la sección de Dashboard"),
             ("fa5s.dumbbell", "Ejercicios", "Explorar biblioteca de ejercicios"),
             ("fa5s.calendar-alt", "Planes", "Gestionar tus planes de entrenamiento"),
             ("fa5s.chart-line", "Progreso", "Consultar historial de análisis"),

--- a/src/gui/widgets/custom_calendar_widget.py
+++ b/src/gui/widgets/custom_calendar_widget.py
@@ -39,6 +39,16 @@ class CustomCalendarWidget(QWidget):
         header_layout.addWidget(self.next_button)
         main_layout.addLayout(header_layout)
 
+        # ----- Encabezado de días de la semana -----
+        week_layout = QGridLayout()
+        week_layout.setSpacing(2)
+        day_names = ["L", "M", "X", "J", "V", "S", "D"]
+        for i, name in enumerate(day_names):
+            lbl = QLabel(name)
+            lbl.setAlignment(Qt.AlignCenter)
+            week_layout.addWidget(lbl, 0, i)
+        main_layout.addLayout(week_layout)
+
         # ----- Grid de días -----
         self.grid_layout = QGridLayout()
         self.grid_layout.setSpacing(2)

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -55,6 +55,11 @@ QListWidget::item {
 QListWidget::item:hover {
   background-color: #3c3c3c;
 }
+/* Panel de navegación lateral */
+QWidget#navPanel {
+    background-color: #1A202C;
+    border-right: 1px solid #4A5568;
+}
 /* Estilo base para todas las tarjetas del dashboard */
 QGroupBox#DashboardCard {
     background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */
@@ -87,6 +92,7 @@ QLabel#kpiSubtitle {
 /* Contenedor principal del calendario personalizado */
 CustomCalendarWidget {
     background-color: transparent;
+    border: none;
 }
 
 /* Cabecera de navegación (Mes y Año) */
@@ -109,11 +115,16 @@ QPushButton#calendarNavButton {
 DayCellWidget {
     background-color: transparent;
     border: none;
+    min-height: 40px;
 }
 
 DayCellWidget QLabel {
     font-size: 10pt;
     font-weight: bold;
+    min-width: 26px;
+    max-width: 26px;
+    min-height: 26px;
+    max-height: 26px;
     color: #CBD5E0;
 }
 

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -51,6 +51,11 @@ QListWidget::item {
 QListWidget::item:hover {
   background-color: #f0f0f0;
 }
+/* Panel de navegación lateral */
+QWidget#navPanel {
+    background-color: #1A202C;
+    border-right: 1px solid #4A5568;
+}
 /* Estilo base para todas las tarjetas del dashboard */
 QGroupBox#DashboardCard {
     background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */
@@ -83,6 +88,7 @@ QLabel#kpiSubtitle {
 /* Contenedor principal del calendario personalizado */
 CustomCalendarWidget {
     background-color: transparent;
+    border: none;
 }
 
 /* Cabecera de navegación (Mes y Año) */
@@ -105,11 +111,16 @@ QPushButton#calendarNavButton {
 DayCellWidget {
     background-color: transparent;
     border: none;
+    min-height: 40px;
 }
 
 DayCellWidget QLabel {
     font-size: 10pt;
     font-weight: bold;
+    min-width: 26px;
+    max-width: 26px;
+    min-height: 26px;
+    max-height: 26px;
     color: #4A5568;
 }
 


### PR DESCRIPTION
## Summary
- style navigation panel for better visual hierarchy
- rename Dashboard tab to Inicio
- add weekday header grid to custom calendar
- adjust calendar QSS styles

## Testing
- `pytest -q`
- `python -m py_compile src/gui/main_window.py src/gui/widgets/custom_calendar_widget.py src/gui/widgets/day_cell_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_685d3cb3e8cc8320acc6b1dc74ccf2f7