### PR TITLE
Add progress card redesign

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -312,6 +312,15 @@ def get_exercise_by_id(exercise_id: int) -> Dict[str, Any] | None:
     return dict(row) if row else None
 
 
+def get_exercise_by_name(name: str) -> Dict[str, Any] | None:
+    """Obtiene un ejercicio por su nombre."""
+    conn = get_db_connection()
+    cursor = conn.execute("SELECT * FROM exercises WHERE name = ?", (name,))
+    row = cursor.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
 def get_all_muscle_groups() -> List[str]:
     """Devuelve la lista de grupos musculares disponibles."""
     conn = get_db_connection()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -88,6 +88,7 @@ class MainWindow(QMainWindow):
 
         # Páginas
         self.dashboard_page = DashboardPage()
+        self.dashboard_page.exercise_selected.connect(self._on_exercise_by_name)
         self.exercises_page = ExercisesPage()
         self.exercises_page.exercise_selected.connect(self._on_exercise_selected)
         self.exercise_detail_page = ExerciseDetailPage(
@@ -163,6 +164,11 @@ class MainWindow(QMainWindow):
         """Carga el detalle del ejercicio seleccionado y navega a la vista."""
         self.exercise_detail_page.load_exercise(exercise_id)
         self._navigate(self.stack.indexOf(self.exercise_detail_page))
+
+    def _on_exercise_by_name(self, name: str) -> None:
+        row = database.get_exercise_by_name(name)
+        if row:
+            self._on_exercise_selected(int(row["id"]))
 
     
 

--- a/src/gui/pages/dashboard_page.py
+++ b/src/gui/pages/dashboard_page.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
 )
-from PyQt5.QtCore import QDate
+from PyQt5.QtCore import QDate, pyqtSignal
 
 from src.gui.widgets.custom_calendar_widget import CustomCalendarWidget
 from src.gui.widgets.daily_plan_card import DailyPlanCard
@@ -12,6 +12,8 @@ from src.gui.widgets.daily_plan_card import DailyPlanCard
 
 class DashboardPage(QWidget):
     """Página principal con un calendario y el plan de entrenamiento del día."""
+
+    exercise_selected = pyqtSignal(str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -24,6 +26,7 @@ class DashboardPage(QWidget):
 
         self.daily_plan_card = DailyPlanCard()
         layout.addWidget(self.daily_plan_card)
+        self.daily_plan_card.exercise_clicked.connect(self.exercise_selected)
 
         self.calendar.date_selected.connect(self._on_date_selected)
 

--- a/src/gui/widgets/daily_plan_card.py
+++ b/src/gui/widgets/daily_plan_card.py
@@ -1,21 +1,41 @@
 from __future__ import annotations
 
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QCheckBox,
+    QProgressBar,
+)
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QGraphicsOpacityEffect
 from typing import Iterable
 import qtawesome as qta
 
 class ExerciseRowWidget(QWidget):
     """Fila individual de ejercicio en el plan diario."""
 
+    checked = pyqtSignal(bool)
+    clicked = pyqtSignal(str)
+
     def __init__(self, name: str, detail: str, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.exercise_name = name
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(6)
+
+        self.check_box = QCheckBox()
+        self.check_box.stateChanged.connect(self.on_checked)
+        layout.addWidget(self.check_box)
+
         self.check_lbl = QLabel()
         self.check_lbl.setPixmap(qta.icon("fa5s.check-circle").pixmap(16, 16))
         self.check_lbl.hide()
         layout.addWidget(self.check_lbl)
+
         self.name_lbl = QLabel(name)
         self.name_lbl.setObjectName("exerciseName")
         layout.addWidget(self.name_lbl)
@@ -24,8 +44,25 @@ class ExerciseRowWidget(QWidget):
         self.detail_lbl.setObjectName("exerciseDetail")
         layout.addWidget(self.detail_lbl)
 
+        self.opacity_effect = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self.opacity_effect)
+
+    # --------------------------------------------------
+    def on_checked(self, state: int) -> None:
+        checked = state == Qt.Checked
+        self.check_lbl.setVisible(checked)
+        self.opacity_effect.setOpacity(0.4 if checked else 1.0)
+        self.checked.emit(checked)
+
+    def mousePressEvent(self, event):  # pragma: no cover - UI interaction
+        self.clicked.emit(self.exercise_name)
+        return super().mousePressEvent(event)
+
+
 class DailyPlanCard(QWidget):
     """Tarjeta que muestra el plan diario de entrenamiento."""
+
+    exercise_clicked = pyqtSignal(str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -39,14 +76,38 @@ class DailyPlanCard(QWidget):
         self.title_lbl.setObjectName("planTitle")
         header_layout.addWidget(self.title_lbl)
         header_layout.addStretch(1)
-        self.subtitle_lbl = QLabel("")
-        self.subtitle_lbl.setObjectName("planSubtitle")
-        header_layout.addWidget(self.subtitle_lbl)
+
+        summary_layout = QHBoxLayout()
+        summary_layout.setContentsMargins(0, 0, 0, 0)
+        summary_layout.setSpacing(4)
+        self.count_icon_lbl = QLabel()
+        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell").pixmap(14, 14))
+        summary_layout.addWidget(self.count_icon_lbl)
+        self.count_lbl = QLabel("")
+        self.count_lbl.setObjectName("planSubtitle")
+        summary_layout.addWidget(self.count_lbl)
+        self.time_icon_lbl = QLabel()
+        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock").pixmap(14, 14))
+        summary_layout.addWidget(self.time_icon_lbl)
+        self.time_lbl = QLabel("")
+        self.time_lbl.setObjectName("planSubtitle")
+        summary_layout.addWidget(self.time_lbl)
+        header_layout.addLayout(summary_layout)
+
         main_layout.addLayout(header_layout)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setObjectName("dayProgress")
+        self.progress_bar.setMaximumHeight(6)
+        self.progress_bar.setTextVisible(False)
+        main_layout.addWidget(self.progress_bar)
 
         self.exercises_layout = QVBoxLayout()
         self.exercises_layout.setSpacing(8)
         main_layout.addLayout(self.exercises_layout)
+
+        self._total_exercises = 0
+        self._completed = 0
 
     # --------------------------------------------------------------
     def update_plan(self, exercises: Iterable[tuple[str, str]]) -> None:
@@ -60,11 +121,31 @@ class DailyPlanCard(QWidget):
         if not exercises_list:
             lbl = QLabel("Descanso. No hay entrenamiento para hoy.")
             self.exercises_layout.addWidget(lbl)
-            self.subtitle_lbl.setText("")
+            self.count_lbl.setText("")
+            self.time_lbl.setText("")
+            self.progress_bar.setValue(0)
             return
 
-        self.subtitle_lbl.setText(f"{len(exercises_list)} ejercicios")
+        self.count_lbl.setText(f"{len(exercises_list)} ejercicios")
+        # Duración estimada simple: 5 min calentamiento + 5 min por ejercicio
+        estimated = 5 + 5 * len(exercises_list)
+        self.time_lbl.setText(f"{estimated} min")
+        self._total_exercises = len(exercises_list)
+        self._completed = 0
+        self.progress_bar.setValue(0)
+
         for name, detail in exercises_list:
             row = ExerciseRowWidget(name, detail)
+            row.checked.connect(self._on_row_checked)
+            row.clicked.connect(self.exercise_clicked)
             self.exercises_layout.addWidget(row)
+
+    def _on_row_checked(self, checked: bool) -> None:
+        if checked:
+            self._completed += 1
+        else:
+            self._completed = max(0, self._completed - 1)
+        if self._total_exercises:
+            percent = int(100 * self._completed / self._total_exercises)
+            self.progress_bar.setValue(percent)
 

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -48,6 +48,11 @@ QLineEdit, QSpinBox, QComboBox {
 QCheckBox {
   spacing: 6px;
 }
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+}
 QListWidget::item {
   padding: 5px;
   border-radius: 3px;
@@ -164,18 +169,28 @@ DailyPlanCard {
 QLabel#planTitle {
     font-size: 12pt;
     font-weight: bold;
-    color: #1A202C;
-    background-color: #F6AD55;
-    padding: 2px 6px;
-    border-radius: 4px;
+    color: #F6AD55;
 }
 
 QLabel#planSubtitle {
     font-size: 9pt;
     color: #1A202C;
-    background-color: #F6AD55;
     padding: 1px 4px;
-    border-radius: 4px;
+}
+
+QProgressBar#dayProgress {
+    background-color: #4A5568;
+    border: none;
+    border-radius: 3px;
+}
+
+QProgressBar#dayProgress::chunk {
+    background-color: #48BB78;
+    border-radius: 3px;
+}
+
+ExerciseRowWidget QCheckBox {
+    spacing: 4px;
 }
 
 ExerciseRowWidget QLabel#exerciseName {

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -44,6 +44,11 @@ QLineEdit, QSpinBox, QComboBox {
 QCheckBox {
   spacing: 6px;
 }
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+}
 QListWidget::item {
   padding: 5px;
   border-radius: 3px;
@@ -160,18 +165,28 @@ DailyPlanCard {
 QLabel#planTitle {
     font-size: 12pt;
     font-weight: bold;
-    color: #1A202C;
-    background-color: #F6AD55;
-    padding: 2px 6px;
-    border-radius: 4px;
+    color: #F6AD55;
 }
 
 QLabel#planSubtitle {
     font-size: 9pt;
     color: #1A202C;
-    background-color: #F6AD55;
     padding: 1px 4px;
-    border-radius: 4px;
+}
+
+QProgressBar#dayProgress {
+    background-color: #E2E8F0;
+    border: none;
+    border-radius: 3px;
+}
+
+QProgressBar#dayProgress::chunk {
+    background-color: #48BB78;
+    border-radius: 3px;
+}
+
+ExerciseRowWidget QCheckBox {
+    spacing: 4px;
 }
 
 ExerciseRowWidget QLabel#exerciseName {


### PR DESCRIPTION
## Summary
- revamp daily plan card with interactive exercise rows and progress bar
- link dashboard card clicks to the exercise detail page
- support exercise lookup by name in the database layer
- update themes with progress bar styling and cleaner headers
- polish checkbox and title styles for clarity

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d4d218f788320b691dcae353741bc