### PR TITLE
Highlight active nav tab

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -151,6 +151,7 @@ class MainWindow(QMainWindow):
 
     def _create_nav_button(self, icon_name: str, text: str, page_index: int, tooltip: str) -> QPushButton:
         btn = QPushButton(text)
+        btn.setObjectName("navButton")
         btn.setIcon(qta.icon(icon_name))
         btn.setCheckable(True)
         btn.setToolTip(tooltip)

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -65,6 +65,25 @@ QWidget#navPanel {
     background-color: #1A202C;
     border-right: 1px solid #4A5568;
 }
+
+QPushButton#navButton {
+    background-color: transparent;
+    color: #ddd;
+    border: none;
+    padding: 6px 12px;
+    text-align: left;
+}
+
+QPushButton#navButton:checked {
+    background-color: #2B6CB0;
+    color: #fff;
+    font-weight: bold;
+    border-left: 4px solid #3182CE;
+}
+
+QPushButton#navButton:hover {
+    background-color: #2D3748;
+}
 /* Estilo base para todas las tarjetas del dashboard */
 QGroupBox#DashboardCard {
     background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -61,6 +61,25 @@ QWidget#navPanel {
     background-color: #1A202C;
     border-right: 1px solid #4A5568;
 }
+
+QPushButton#navButton {
+    background-color: transparent;
+    color: #eee;
+    border: none;
+    padding: 6px 12px;
+    text-align: left;
+}
+
+QPushButton#navButton:checked {
+    background-color: #3182CE;
+    color: #fff;
+    font-weight: bold;
+    border-left: 4px solid #2B6CB0;
+}
+
+QPushButton#navButton:hover {
+    background-color: #2D3748;
+}
 /* Estilo base para todas las tarjetas del dashboard */
 QGroupBox#DashboardCard {
     background-color: #2D3748; /* Un color de fondo oscuro para las tarjetas */


### PR DESCRIPTION
## Summary
- highlight which nav button is currently selected with accent left border
- tweak dark and light theme styles

## Testing
- `python -m py_compile src/gui/main_window.py`
- `python -m py_compile src/gui/pages/exercises_page.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d5dde21ec8320b73a19745f5cdf6b