### PR TITLE
Add debug prints for image loading

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -53,6 +53,7 @@ class MainWindow(QMainWindow):
         """
         super().__init__(parent)
         self.project_root = project_root
+        print(f"DEBUG: Ruta Raíz del Proyecto detectada: {self.project_root}")
         self.translator = translator
         self.video_path: Optional[str] = None
         self.gui_settings: Dict[str, Any] = {}

--- a/src/gui/pages/exercises_page.py
+++ b/src/gui/pages/exercises_page.py
@@ -113,6 +113,7 @@ class ExercisesPage(QWidget):
                 icon_path_absolute = ""
                 if icon_path_relative:
                     icon_path_absolute = os.path.join(self.project_root, icon_path_relative)
+                    print(f"DEBUG: Intentando cargar icono desde: {icon_path_absolute}")
 
                 card = ExerciseCardWidget(
                     int(ex["id"]),

--- a/src/gui/widgets/exercise_card_widget.py
+++ b/src/gui/widgets/exercise_card_widget.py
@@ -45,6 +45,8 @@ class ExerciseCardWidget(QWidget):
 
     # --------------------------------------------------
     def _load_image(self) -> None:
+        print(f"DEBUG: La tarjeta '{self.name_label.text()}' recibió la ruta: {self.image_path}")
+        print(f"DEBUG: ¿Existe el archivo en esa ruta? -> {os.path.exists(self.image_path)}")
         pix = None
         if self.image_path and os.path.exists(self.image_path):
             tmp = QPixmap(self.image_path)


### PR DESCRIPTION
## Summary
- add project root debug output in `MainWindow`
- log absolute icon paths in `ExercisesPage`
- log received image path and existence check in `ExerciseCardWidget`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7bff809c8320850819fdbeca2e42