### PR TITLE
Improve ExerciseCardWidget layout and hover styles

### DIFF
--- a/src/gui/widgets/exercise_card_widget.py
+++ b/src/gui/widgets/exercise_card_widget.py
@@ -1,65 +1,82 @@
 from __future__ import annotations
 import os
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QStyle
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal, QSize
 from PyQt5.QtGui import QPixmap
 
 
 class ExerciseCardWidget(QWidget):
-    """Tarjeta visual para un ejercicio individual."""
+    """
+    Tarjeta visual robusta para un ejercicio.
+    Gestiona el escalado de imagen dinámicamente.
+    """
 
     clicked = pyqtSignal(int)
 
-    def __init__(self, ex_id: int, name: str, icon_path: str | None,
-                 equipment: str | None = None,
-                 parent: QWidget | None = None) -> None:
+    def __init__(self, ex_id: int, name: str, icon_path: str | None, equipment: str | None = None, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.exercise_id = ex_id
         self.image_path = icon_path or ""
-        self.name = name
-        self.equipment = equipment
 
+        # --- Configuración del Widget Principal ---
         self.setObjectName("ExerciseCardWidget")
-        self.setFixedSize(160, 190)
+        self.setMinimumSize(160, 190)
         self.setCursor(Qt.PointingHandCursor)
+        self.setAttribute(Qt.WA_Hover)
 
+        # --- Layout y Contenido ---
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(6)
+        layout.setSpacing(4)
 
         self.image_label = QLabel()
         self.image_label.setAlignment(Qt.AlignCenter)
-        self.image_label.setFixedHeight(120)
-        layout.addWidget(self.image_label)
+        layout.addWidget(self.image_label, 1)
 
-        self.name_label = QLabel(self.name)
+        text_container = QWidget()
+        text_layout = QVBoxLayout(text_container)
+        text_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.name_label = QLabel(name)
         self.name_label.setObjectName("exerciseCardName")
         self.name_label.setAlignment(Qt.AlignCenter)
         self.name_label.setWordWrap(True)
-        layout.addWidget(self.name_label)
+        text_layout.addWidget(self.name_label)
 
-        if self.equipment:
-            self.equipment_label = QLabel(self.equipment)
+        if equipment:
+            self.equipment_label = QLabel(equipment)
             self.equipment_label.setObjectName("exerciseCardEquipment")
             self.equipment_label.setAlignment(Qt.AlignCenter)
-            layout.addWidget(self.equipment_label)
+            text_layout.addWidget(self.equipment_label)
 
-        layout.addStretch()
+        layout.addWidget(text_container)
 
-        self._load_and_scale_image()
+        self.original_pixmap = self._load_original_pixmap()
 
-    def _load_and_scale_image(self) -> None:
-        """Carga y escala la imagen, con fallback a un icono de advertencia."""
+    def _load_original_pixmap(self) -> QPixmap:
+        """Carga la imagen original desde el disco una sola vez."""
         pixmap = QPixmap(self.image_path)
         if pixmap.isNull():
             icon = self.style().standardIcon(QStyle.SP_MessageBoxWarning)
-            pixmap = icon.pixmap(64, 64)
+            return icon.pixmap(64, 64)
+        return pixmap
 
-        scaled = pixmap.scaledToHeight(self.image_label.height(),
-                                       Qt.SmoothTransformation)
-        self.image_label.setPixmap(scaled)
+    def resizeEvent(self, event) -> None:
+        """
+        Este evento se dispara cada vez que el widget cambia de tamaño.
+        Aquí es donde debemos re-escalar la imagen.
+        """
+        super().resizeEvent(event)
+        if self.original_pixmap:
+            scaled_pixmap = self.original_pixmap.scaled(
+                self.image_label.size(),
+                Qt.KeepAspectRatio,
+                Qt.SmoothTransformation
+            )
+            self.image_label.setPixmap(scaled_pixmap)
 
-    def mousePressEvent(self, event):  # pragma: no cover - UI interaction
+    def mousePressEvent(self, event) -> None:
+        """Emite la señal de clic."""
         if event.button() == Qt.LeftButton:
             self.clicked.emit(self.exercise_id)
         super().mousePressEvent(event)

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -265,6 +265,7 @@ QWidget#ExerciseCardWidget:hover {
 
 QLabel#exerciseCardName {
     font-weight: bold;
+    font-size: 10pt; /* Tamaño de fuente explícito */
     color: #E2E8F0;
 }
 

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -261,6 +261,7 @@ QWidget#ExerciseCardWidget:hover {
 
 QLabel#exerciseCardName {
     font-weight: bold;
+    font-size: 10pt; /* Tamaño de fuente explícito */
     color: #2D3748;
 }
 


### PR DESCRIPTION
## Summary
- rewrite `ExerciseCardWidget` to scale images responsively and add hover support
- adjust dark and light theme styles for the new widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d845f35808320bf00a7a32d909f7f