### PR TITLE
Fix missing carousel height

### DIFF
--- a/src/gui/pages/exercises_page.py
+++ b/src/gui/pages/exercises_page.py
@@ -95,6 +95,7 @@ class ExercisesPage(QWidget):
             self.group_sections[grp] = title
 
             ex_scroll = QScrollArea()
+            ex_scroll.setFixedHeight(220)
             ex_scroll.setWidgetResizable(True)
             ex_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
             ex_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)


### PR DESCRIPTION
## Summary
- fix exercises page carousels by adding a fixed height

## Testing
- `python -m compileall -q src/gui/pages/exercises_page.py`

------
https://chatgpt.com/codex/tasks/task_e_685da4a5dcb48320b04cedc41fdbaa9c