### PR TITLE
Introduce collapsible exercise sections

### DIFF
--- a/src/gui/pages/exercises_page.py
+++ b/src/gui/pages/exercises_page.py
@@ -4,15 +4,18 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QComboBox,
     QScrollArea,
+    QGridLayout,
+    QApplication,
     QLabel,
     QHBoxLayout,
-    QApplication,
+    QPushButton,
 )
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QMovie
 from pathlib import Path
 
 from ..widgets.exercise_card_widget import ExerciseCardWidget
+from ..widgets.collapsible_section import CollapsibleSection
 
 from ... import database
 
@@ -28,8 +31,15 @@ class ExercisesPage(QWidget):
 
         layout = QVBoxLayout(self)
 
+        controls_layout = QHBoxLayout()
         self.group_combo = QComboBox()
-        layout.addWidget(self.group_combo)
+        controls_layout.addWidget(self.group_combo)
+        self.expand_all_btn = QPushButton("Expand All")
+        self.collapse_all_btn = QPushButton("Collapse All")
+        controls_layout.addWidget(self.expand_all_btn)
+        controls_layout.addWidget(self.collapse_all_btn)
+        controls_layout.addStretch()
+        layout.addLayout(controls_layout)
 
         self.loading_label = QLabel()
         self.loading_label.setAlignment(Qt.AlignCenter)
@@ -49,8 +59,11 @@ class ExercisesPage(QWidget):
         self.scroll_area.setWidget(self.container)
 
         self.group_combo.currentTextChanged.connect(self.on_group_selected)
+        self.expand_all_btn.clicked.connect(self.expand_all)
+        self.collapse_all_btn.clicked.connect(self.collapse_all)
 
-        self.group_sections: dict[str, QWidget] = {}
+        self.group_sections: dict[str, CollapsibleSection] = {}
+        self.section_info: dict[str, dict[str, object]] = {}
 
         self.refresh_groups()
 
@@ -67,6 +80,7 @@ class ExercisesPage(QWidget):
         QApplication.processEvents()
 
         self._build_sections(groups)
+        self._update_grid_columns()
 
         self.loading_movie.stop()
         self.loading_label.hide()
@@ -89,26 +103,13 @@ class ExercisesPage(QWidget):
         self.group_sections.clear()
 
         for grp in groups:
-            title = QLabel(grp)
-            title.setObjectName("muscleGroupTitle")
-            self.scroll_layout.addWidget(title)
-            self.group_sections[grp] = title
-
-            ex_scroll = QScrollArea()
-            ex_scroll.setFixedHeight(220)
-            ex_scroll.setWidgetResizable(True)
-            ex_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-            ex_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-
-            cont = QWidget()
-            h_layout = QHBoxLayout(cont)
-            h_layout.setContentsMargins(2, 2, 2, 2)
-            h_layout.setSpacing(8)
-
-            ex_scroll.setWidget(cont)
-            self.scroll_layout.addWidget(ex_scroll)
+            grid_container = QWidget()
+            grid_layout = QGridLayout(grid_container)
+            grid_layout.setContentsMargins(2, 2, 2, 2)
+            grid_layout.setSpacing(8)
 
             exercises = database.get_exercises_by_group(grp)
+            cards: list[ExerciseCardWidget] = []
             for ex in exercises:
                 icon_path_relative = ex.get("icon_path", "")
                 icon_path_absolute = ""
@@ -123,7 +124,48 @@ class ExercisesPage(QWidget):
                     ex.get("equipment"),
                 )
                 card.clicked.connect(self.exercise_selected)
-                h_layout.addWidget(card)
+                cards.append(card)
 
-            h_layout.addStretch(1)
+            section = CollapsibleSection(grp, grid_container)
+            self.scroll_layout.addWidget(section)
+            self.group_sections[grp] = section
+            self.section_info[grp] = {
+                "layout": grid_layout,
+                "cards": cards,
+                "container": grid_container,
+            }
+
+    def _update_grid_columns(self) -> None:
+        """Reorganize cards based on the available width."""
+        width = self.scroll_area.viewport().width()
+        columns = max(3, min(6, width // 200))
+        for info in self.section_info.values():
+            layout: QGridLayout = info["layout"]  # type: ignore[assignment]
+            cards: list[ExerciseCardWidget] = info["cards"]  # type: ignore[assignment]
+
+            while layout.count():
+                item = layout.takeAt(0)
+                if item.widget():
+                    item.widget().setParent(info["container"])
+
+            row = 0
+            col = 0
+            for card in cards:
+                layout.addWidget(card, row, col)
+                col += 1
+                if col >= columns:
+                    col = 0
+                    row += 1
+
+    def resizeEvent(self, event) -> None:  # type: ignore[override]
+        super().resizeEvent(event)
+        self._update_grid_columns()
+
+    def expand_all(self) -> None:
+        for section in self.group_sections.values():
+            section.expand()
+
+    def collapse_all(self) -> None:
+        for section in self.group_sections.values():
+            section.collapse()
 

--- a/src/gui/widgets/collapsible_section.py
+++ b/src/gui/widgets/collapsible_section.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton
+from PyQt5.QtCore import (
+    Qt,
+    QPropertyAnimation,
+    QEasingCurve,
+    QParallelAnimationGroup,
+    pyqtProperty,
+)
+from PyQt5.QtGui import QIcon, QPixmap, QTransform
+
+try:
+    import qtawesome as qta  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    qta = None
+
+
+class _RotatableButton(QPushButton):
+    """QPushButton with a rotatable icon used for the chevron."""
+
+    def __init__(
+        self,
+        text: str,
+        normal_pixmap: QPixmap,
+        hover_pixmap: QPixmap,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(text, parent)
+        self._angle = 0.0
+        self._normal_pixmap = normal_pixmap
+        self._hover_pixmap = hover_pixmap
+        self._base_pixmap = normal_pixmap
+        self.setIcon(QIcon(normal_pixmap))
+        self.setIconSize(normal_pixmap.size())
+        self.setCursor(Qt.PointingHandCursor)
+
+    def getAngle(self) -> float:
+        return self._angle
+
+    def setAngle(self, angle: float) -> None:
+        self._angle = angle
+        transform = QTransform().rotate(angle)
+        rotated = self._base_pixmap.transformed(
+            transform, Qt.SmoothTransformation
+        )
+        self.setIcon(QIcon(rotated))
+
+    angle = pyqtProperty(float, fget=getAngle, fset=setAngle)
+
+    # ------------------------------------------------------
+    def enterEvent(self, event) -> None:  # type: ignore[override]
+        self._base_pixmap = self._hover_pixmap or self._normal_pixmap
+        self.setAngle(self._angle)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:  # type: ignore[override]
+        self._base_pixmap = self._normal_pixmap
+        self.setAngle(self._angle)
+        super().leaveEvent(event)
+
+
+class CollapsibleSection(QWidget):
+    """A section with a clickable header that expands/collapses its content."""
+
+    def __init__(self, title: str, content_widget: QWidget, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._content = content_widget
+        self._content.setObjectName("GridContentContainer")
+
+        normal_pixmap = QPixmap()
+        hover_pixmap = QPixmap()
+        if qta is not None:
+            try:
+                normal_pixmap = qta.icon(
+                    "fa5s.chevron-right", color="#F6AD55"
+                ).pixmap(14, 14)
+                hover_pixmap = qta.icon(
+                    "fa5s.chevron-right", color="#FFFFFF"
+                ).pixmap(14, 14)
+            except Exception:
+                normal_pixmap = QPixmap()
+                hover_pixmap = QPixmap()
+
+        self.header_btn = _RotatableButton(title, normal_pixmap, hover_pixmap)
+        self.header_btn.setObjectName("CollapsibleHeader")
+        self.header_btn.setCheckable(True)
+        self.header_btn.setChecked(True)
+        self.header_btn.clicked.connect(self.toggle)
+
+        self.header_btn.setAngle(90)  # start expanded
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.header_btn)
+        layout.addWidget(self._content)
+
+        self._content.setMaximumHeight(self._content.sizeHint().height())
+
+        self._content_anim = QPropertyAnimation(self._content, b"maximumHeight")
+        self._content_anim.setEasingCurve(QEasingCurve.InOutQuad)
+        self._content_anim.setDuration(150)
+
+        self._arrow_anim = QPropertyAnimation(self.header_btn, b"angle")
+        self._arrow_anim.setEasingCurve(QEasingCurve.InOutQuad)
+        self._arrow_anim.setDuration(150)
+
+        self._anim_group = QParallelAnimationGroup()
+        self._anim_group.addAnimation(self._content_anim)
+        self._anim_group.addAnimation(self._arrow_anim)
+
+        self._expanded = True
+
+    # ----------------------------------------------------------
+    def toggle(self) -> None:
+        """Toggle between expanded and collapsed state with animation."""
+        full_height = self._content.sizeHint().height()
+        if self._expanded:
+            self._content_anim.setStartValue(full_height)
+            self._content_anim.setEndValue(0)
+            self._arrow_anim.setStartValue(90)
+            self._arrow_anim.setEndValue(0)
+        else:
+            self._content_anim.setStartValue(0)
+            self._content_anim.setEndValue(full_height)
+            self._arrow_anim.setStartValue(0)
+            self._arrow_anim.setEndValue(90)
+        self._anim_group.start()
+        self._expanded = not self._expanded
+
+    def expand(self) -> None:
+        """Expand the section if it is collapsed."""
+        if not self._expanded:
+            self.toggle()
+
+    def collapse(self) -> None:
+        """Collapse the section if it is expanded."""
+        if self._expanded:
+            self.toggle()

--- a/src/gui/widgets/exercise_card_widget.py
+++ b/src/gui/widgets/exercise_card_widget.py
@@ -20,7 +20,7 @@ class ExerciseCardWidget(QWidget):
 
         # --- Configuración del Widget Principal ---
         self.setObjectName("ExerciseCardWidget")
-        self.setMinimumSize(160, 190)
+        self.setMinimumSize(180, 180)
         self.setCursor(Qt.PointingHandCursor)
         self.setAttribute(Qt.WA_Hover, True)
 
@@ -31,7 +31,7 @@ class ExerciseCardWidget(QWidget):
 
         self.image_label = QLabel()
         self.image_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.image_label, 1)
+        layout.addWidget(self.image_label, 3)
 
         text_container = QWidget()
         text_layout = QVBoxLayout(text_container)
@@ -49,7 +49,7 @@ class ExerciseCardWidget(QWidget):
             self.equipment_label.setAlignment(Qt.AlignCenter)
             text_layout.addWidget(self.equipment_label)
 
-        layout.addWidget(text_container, 0)
+        layout.addWidget(text_container, 1)
 
         self.original_pixmap = self._load_original_pixmap()
 

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -287,3 +287,23 @@ QScrollArea QScrollBar::handle:horizontal {
     min-width: 20px;
     border-radius: 4px;
 }
+
+QPushButton#CollapsibleHeader {
+    background-color: transparent;
+    border: none;
+    color: #F6AD55;
+    font-size: 16pt;
+    font-weight: bold;
+    text-align: left;
+    padding: 8px 5px;
+}
+
+QPushButton#CollapsibleHeader:hover {
+    background-color: #2D3748;
+    color: #FFFFFF;
+}
+
+QWidget#GridContentContainer {
+    border-top: 1px solid #4A5568;
+    background-color: transparent;
+}

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -283,3 +283,23 @@ QScrollArea QScrollBar::handle:horizontal {
     min-width: 20px;
     border-radius: 4px;
 }
+
+QPushButton#CollapsibleHeader {
+    background-color: transparent;
+    border: none;
+    color: #F6AD55;
+    font-size: 16pt;
+    font-weight: bold;
+    text-align: left;
+    padding: 8px 5px;
+}
+
+QPushButton#CollapsibleHeader:hover {
+    background-color: #2D3748;
+    color: #FFFFFF;
+}
+
+QWidget#GridContentContainer {
+    border-top: 1px solid #4A5568;
+    background-color: transparent;
+}


### PR DESCRIPTION
## Summary
- add `CollapsibleSection` widget with animated header
- tweak `ExerciseCardWidget` to a square shape
- use new collapsible sections and grid layout on ExercisesPage
- style collapsible widgets in light and dark themes
- add "Expand All" and "Collapse All" controls
- change chevron hover color and support responsive grid columns

## Testing
- `python -m py_compile src/gui/widgets/collapsible_section.py src/gui/widgets/exercise_card_widget.py src/gui/pages/exercises_page.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5bfd3be48320880e447b36983a0e