### PR TITLE
Remove qproperty icon colors and use theme dict

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -38,6 +38,11 @@ from .pages import (
 
 logger = logging.getLogger(__name__)
 
+THEME_COLORS = {
+    "dark": {"default": "#FFB74D", "checked": "#FFFFFF"},
+    "light": {"default": "#FFFFFF", "checked": "#FFB74D"},
+}
+
 class MainWindow(QMainWindow):
     """
     Ventana principal de la aplicación. Orquesta todos los widgets y la interacción
@@ -172,13 +177,12 @@ class MainWindow(QMainWindow):
         return btn
 
     def _update_nav_icons(self) -> None:
-        """Repaint navigation icons using colors defined in the active theme."""
-        default_color = self.nav_widget.property("iconColor")
-        checked_color = self.nav_widget.property("iconColorChecked")
+        """Repaint navigation icons using the centralized theme color config."""
+        theme_name = "dark" if self._is_dark_theme else "light"
+        colors = THEME_COLORS[theme_name]
 
-        if not default_color or not checked_color:
-            default_color = "#FFFFFF"
-            checked_color = "#FFB74D"
+        default_color = colors["default"]
+        checked_color = colors["checked"]
 
         for btn in getattr(self, "nav_buttons", []):
             icon_name = btn.property("icon_name")
@@ -206,7 +210,7 @@ class MainWindow(QMainWindow):
         self._is_dark_theme = is_dark
         load_stylesheet(QApplication.instance(), self.project_root, dark=is_dark)
 
-        # After applying the theme the nav_widget has updated properties
+        # Refresh icons with new theme colors
         self._update_nav_icons()
 
         if hasattr(self, 'progress_page'):

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -64,8 +64,6 @@ QListWidget::item:hover {
 QWidget#navPanel {
     background-color: #1A202C;
     border-right: 1px solid #4A5568;
-    qproperty-iconColor: #FFB74D;
-    qproperty-iconColorChecked: #FFFFFF;
 }
 
 QPushButton#navButton {

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -60,8 +60,6 @@ QListWidget::item:hover {
 QWidget#navPanel {
     background-color: #1A202C;
     border-right: 1px solid #4A5568;
-    qproperty-iconColor: #FFFFFF;
-    qproperty-iconColorChecked: #FFB74D;
 }
 
 QPushButton#navButton {


### PR DESCRIPTION
## Summary
- clean up QSS files by removing unused `qproperty` definitions
- define `THEME_COLORS` dictionary in `main_window.py`
- repaint navigation icons using the centralized color dictionary
- update comment in `_apply_theme`

## Testing
- `python -m py_compile src/gui/main_window.py`
- `python -m unittest discover` *(fails: ModuleNotFoundError for cv2 and PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_685e704540d483208db8791143713348