### PR TITLE
Redesign Plans page

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -136,6 +136,28 @@ def get_all_training_plans() -> list:
     rows = conn.execute("SELECT * FROM training_plans ORDER BY timestamp DESC").fetchall()
     conn.close()
     return [dict(row) for row in rows]
+
+def save_training_plan(title: str, plan_content_md: str) -> int:
+    """Guarda un nuevo plan de entrenamiento y devuelve su ID."""
+    conn = get_db_connection()
+    with conn:
+        cur = conn.execute(
+            "INSERT INTO training_plans(title, timestamp, plan_content_md) VALUES (?, ?, ?)",
+            (title, datetime.utcnow().isoformat(), plan_content_md),
+        )
+        plan_id = cur.lastrowid
+    conn.close()
+    return int(plan_id)
+
+def get_plan_by_id(plan_id: int) -> Dict[str, Any] | None:
+    """Obtiene un plan de entrenamiento por su ID."""
+    conn = get_db_connection()
+    row = conn.execute(
+        "SELECT * FROM training_plans WHERE id = ?",
+        (plan_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
     
 def get_logs_for_exercise(exercise_id: int) -> List[Dict[str, Any]]:
     conn = get_db_connection()

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -301,6 +301,22 @@ QPushButton#CollapsibleHeader:hover {
     color: #FFFFFF;
 }
 
+QWidget#planScrollContainer {
+    background-color: #1E2530;
+    border-radius: 6px;
+    padding: 8px;
+}
+
+QPushButton#PrimaryCTAButton {
+    background-color: #2B6CB0;
+    color: #FFFFFF;
+    font-weight: bold;
+}
+
+QPushButton#PrimaryCTAButton:hover {
+    background-color: #3C82D8;
+}
+
 QWidget#GridContentContainer {
     border-top: 1px solid #4A5568;
     background-color: transparent;

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -297,6 +297,22 @@ QPushButton#CollapsibleHeader:hover {
     color: #FFFFFF;
 }
 
+QWidget#planScrollContainer {
+    background-color: #F7FAFC;
+    border-radius: 6px;
+    padding: 8px;
+}
+
+QPushButton#PrimaryCTAButton {
+    background-color: #2B6CB0;
+    color: #FFFFFF;
+    font-weight: bold;
+}
+
+QPushButton#PrimaryCTAButton:hover {
+    background-color: #3C82D8;
+}
+
 QWidget#GridContentContainer {
     border-top: 1px solid #4A5568;
     background-color: transparent;


### PR DESCRIPTION
## Summary
- add `save_training_plan` and `get_plan_by_id` helpers
- ensure sample plan is stored and set as active on first run
- load active plan in DashboardPage and PlansPage
- style the Plans page scroll container and CTA button

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e7ca4f8fc8320b77a2eb275a7cf05