### PR TITLE
Improve plans page UX with calendar and styling tweaks

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -111,6 +111,7 @@ class MainWindow(QMainWindow):
         self.progress_page = ProgressPage()
         self.results_panel = self.progress_page.results_panel
         self.plans_page = PlansPage(self.translator)
+        self.plans_page.exercise_selected.connect(self._on_exercise_by_name)
         self.settings_page = SettingsPage(self._apply_theme)
         self.contact_page = ContactPage()
 

--- a/src/gui/pages/plans_page.py
+++ b/src/gui/pages/plans_page.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
 from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -14,11 +15,14 @@ from PyQt5.QtWidgets import (
     QStackedWidget,
     QDialog,
     QMessageBox,
+    QInputDialog,
+    QHBoxLayout,
 )
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QMovie
 
 from ..widgets.daily_plan_card import DailyPlanCard
+from ..widgets.mini_calendar_widget import MiniCalendarWidget
 from ...services.plan_generator import PlanGeneratorWorker
 from ... import database
 
@@ -63,6 +67,8 @@ sample_plan = {
 # ---------------------------------------------------------------------------
 class PlanGeneratorDialog(QDialog):
     """Diálogo para generar un nuevo plan de entrenamiento."""
+
+    plan_saved = pyqtSignal()
 
     def __init__(self, translator, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -116,8 +122,17 @@ class PlanGeneratorDialog(QDialog):
 
         layout.addWidget(self.results_stack, 1)
 
+        btn_layout = QHBoxLayout()
+        self.save_btn = QPushButton(self.translator.tr("save_plan"))
+        self.save_activate_btn = QPushButton("Guardar y Activar")
+        btn_layout.addWidget(self.save_btn)
+        btn_layout.addWidget(self.save_activate_btn)
+        layout.addLayout(btn_layout)
+
         self.worker = None
         self.generate_btn.clicked.connect(self.on_generate_plan_clicked)
+        self.save_btn.clicked.connect(self._on_save_clicked)
+        self.save_activate_btn.clicked.connect(self._on_save_activate_clicked)
 
     # --------------------------------------------------
     def on_generate_plan_clicked(self) -> None:
@@ -148,10 +163,56 @@ class PlanGeneratorDialog(QDialog):
         self.results_text_edit.setPlainText("")
         QMessageBox.critical(self, "Error generando plan", error_message)
 
+    # --------------------------------------------------
+    def _on_save_clicked(self) -> None:
+        self._save_plan(activate=False)
+
+    # --------------------------------------------------
+    def _on_save_activate_clicked(self) -> None:
+        if self._save_plan(activate=True):
+            self.accept()
+
+    # --------------------------------------------------
+    def _save_plan(self, activate: bool) -> int | None:
+        md = self.results_text_edit.toPlainText().strip()
+        if not md:
+            QMessageBox.warning(self, "Error", "No hay plan para guardar")
+            return None
+        title, ok = QInputDialog.getText(self, "Nombre del Plan", "Título:")
+        if not ok or not title.strip():
+            return None
+        plan_id = database.save_training_plan(title.strip(), md)
+        if activate:
+            database.set_app_state("active_plan_id", str(plan_id))
+        self.plan_saved.emit()
+        return plan_id
+
+
+class SwitchPlanDialog(QDialog):
+    """Dialogo para elegir otro plan guardado."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Seleccionar Plan")
+
+        layout = QVBoxLayout(self)
+        self.plan_cb = QComboBox()
+        for row in database.get_all_training_plans():
+            self.plan_cb.addItem(row.get("title", ""), row.get("id"))
+        layout.addWidget(self.plan_cb)
+        btn = QPushButton("Seleccionar")
+        btn.clicked.connect(self.accept)
+        layout.addWidget(btn)
+
+    def selected_plan_id(self) -> int | None:
+        return self.plan_cb.currentData()
+
 
 # ---------------------------------------------------------------------------
 class PlansPage(QWidget):
     """Página que muestra el plan de entrenamiento activo."""
+
+    exercise_selected = pyqtSignal(str)
 
     def __init__(self, translator, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -162,9 +223,26 @@ class PlansPage(QWidget):
 
         plan_dict = self._load_active_plan_dict()
 
-        title = QLabel(f"Plan Activo: {plan_dict['plan_name']}")
-        title.setObjectName("planTitle")
-        layout.addWidget(title)
+        header_layout = QHBoxLayout()
+        self.title_lbl = QLabel(f"Plan Activo: {plan_dict['plan_name']}")
+        self.title_lbl.setObjectName("planTitle")
+        header_layout.addWidget(self.title_lbl)
+        header_layout.addStretch(1)
+        self.switch_plan_btn = QPushButton("Cambiar Plan")
+        self.switch_plan_btn.clicked.connect(self._on_switch_plan)
+        header_layout.addWidget(self.switch_plan_btn)
+        layout.addLayout(header_layout)
+
+        self.mini_calendar = MiniCalendarWidget()
+        layout.addWidget(self.mini_calendar)
+
+        start_week = date.today() - timedelta(days=date.today().weekday())
+        workout_dates = [
+            start_week + timedelta(days=i)
+            for i, day in enumerate(plan_dict["days"])
+            if day.get("exercises")
+        ]
+        self.mini_calendar.set_workout_dates(workout_dates)
 
         self.scroll_area = QScrollArea()
         self.scroll_area.setWidgetResizable(True)
@@ -183,6 +261,7 @@ class PlansPage(QWidget):
                 (ex["name"], ex["detail"]) for ex in day.get("exercises", [])
             ]
             card.update_plan(exercises)
+            card.exercise_clicked.connect(self.exercise_selected)
             self.scroll_layout.addWidget(card)
 
         self.scroll_layout.addStretch(1)
@@ -195,7 +274,43 @@ class PlansPage(QWidget):
     # --------------------------------------------------
     def _open_generator_dialog(self) -> None:
         dlg = PlanGeneratorDialog(self.translator, self)
+        dlg.plan_saved.connect(self._refresh_plan)
         dlg.exec_()
+
+    # --------------------------------------------------
+    def _on_switch_plan(self) -> None:
+        dlg = SwitchPlanDialog(self)
+        if dlg.exec_():
+            plan_id = dlg.selected_plan_id()
+            if plan_id is not None:
+                database.set_app_state("active_plan_id", str(plan_id))
+                self._refresh_plan()
+
+    # --------------------------------------------------
+    def _refresh_plan(self) -> None:
+        while self.scroll_layout.count():
+            item = self.scroll_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+        plan_dict = self._load_active_plan_dict()
+        self.title_lbl.setText(f"Plan Activo: {plan_dict['plan_name']}")
+        start_week = date.today() - timedelta(days=date.today().weekday())
+        workout_dates = []
+        for i, day in enumerate(plan_dict["days"]):
+            card = DailyPlanCard()
+            card.title_lbl.setText(day["day_name"])
+            exercises = [
+                (ex["name"], ex["detail"]) for ex in day.get("exercises", [])
+            ]
+            card.update_plan(exercises)
+            card.exercise_clicked.connect(self.exercise_selected)
+            self.scroll_layout.addWidget(card)
+            if exercises:
+                workout_dates.append(start_week + timedelta(days=i))
+
+        self.mini_calendar.set_workout_dates(workout_dates)
+        self.scroll_layout.addStretch(1)
 
     # --------------------------------------------------
     def _parse_plan_md(self, md: str) -> dict:

--- a/src/gui/widgets/daily_plan_card.py
+++ b/src/gui/widgets/daily_plan_card.py
@@ -84,18 +84,20 @@ class DailyPlanCard(QWidget):
         summary_layout.setContentsMargins(0, 0, 0, 0)
         summary_layout.setSpacing(4)
         self.count_icon_lbl = QLabel()
-        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell").pixmap(14, 14))
-        summary_layout.addWidget(self.count_icon_lbl)
         self.count_lbl = QLabel("")
-        self.count_lbl.setObjectName("planSubtitle")
+        self.count_lbl.setObjectName("planInfo")
+        summary_layout.addWidget(self.count_icon_lbl)
         summary_layout.addWidget(self.count_lbl)
         self.time_icon_lbl = QLabel()
-        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock").pixmap(14, 14))
-        summary_layout.addWidget(self.time_icon_lbl)
         self.time_lbl = QLabel("")
-        self.time_lbl.setObjectName("planSubtitle")
+        self.time_lbl.setObjectName("planInfo")
+        summary_layout.addWidget(self.time_icon_lbl)
         summary_layout.addWidget(self.time_lbl)
         header_layout.addLayout(summary_layout)
+
+        color = self.property("summaryIconColor") or "#A0AEC0"
+        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell", color=color).pixmap(14, 14))
+        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock", color=color).pixmap(14, 14))
 
         main_layout.addLayout(header_layout)
 
@@ -108,6 +110,10 @@ class DailyPlanCard(QWidget):
         self.exercises_layout = QVBoxLayout()
         self.exercises_layout.setSpacing(8)
         main_layout.addLayout(self.exercises_layout)
+
+        self.rest_label = QLabel("Descanso. No hay entrenamiento para hoy.")
+        main_layout.addWidget(self.rest_label)
+        self.rest_label.hide()
 
         self.start_btn = QPushButton("Empezar Entrenamiento")
         self.start_btn.setObjectName("startTrainingButton")
@@ -126,14 +132,22 @@ class DailyPlanCard(QWidget):
                 item.widget().deleteLater()
 
         exercises_list = list(exercises)
-        if not exercises_list:
-            lbl = QLabel("Descanso. No hay entrenamiento para hoy.")
-            self.exercises_layout.addWidget(lbl)
+        has_exercises = bool(exercises_list)
+        self.start_btn.setVisible(has_exercises)
+        self.rest_label.setVisible(not has_exercises)
+        self.setProperty("isRestDay", not has_exercises)
+        self.style().unpolish(self)
+        self.style().polish(self)
+        if not has_exercises:
             self.count_lbl.setText("")
             self.time_lbl.setText("")
             self.progress_bar.setValue(0)
             self.start_btn.setEnabled(False)
             return
+
+        color = self.property("summaryIconColor") or "#A0AEC0"
+        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell", color=color).pixmap(14, 14))
+        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock", color=color).pixmap(14, 14))
 
         self.count_lbl.setText(f"{len(exercises_list)} ejercicios")
         # Duración estimada simple: 5 min calentamiento + 5 min por ejercicio

--- a/src/gui/widgets/mini_calendar_widget.py
+++ b/src/gui/widgets/mini_calendar_widget.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel
+from PyQt5.QtCore import Qt
+from typing import Iterable
+
+
+class MiniCalendarWidget(QWidget):
+    """Small, non-interactive calendar showing the current week."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._cells: list[tuple[QWidget, QLabel, QLabel]] = []
+        self._workout_dates: set[date] = set()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        for _ in range(7):
+            cell = QWidget()
+            cell_layout = QVBoxLayout(cell)
+            cell_layout.setContentsMargins(2, 2, 2, 2)
+            cell_layout.setAlignment(Qt.AlignCenter)
+
+            day_lbl = QLabel()
+            day_lbl.setObjectName("miniCalDayName")
+            day_lbl.setAlignment(Qt.AlignCenter)
+            num_lbl = QLabel()
+            num_lbl.setObjectName("miniCalDayNumber")
+            num_lbl.setAlignment(Qt.AlignCenter)
+
+            cell_layout.addWidget(day_lbl)
+            cell_layout.addWidget(num_lbl)
+
+            layout.addWidget(cell)
+            self._cells.append((cell, day_lbl, num_lbl))
+
+        self.update_week()
+
+    # --------------------------------------------------------------
+    def set_workout_dates(self, dates: Iterable[date]) -> None:
+        self._workout_dates = set(dates)
+        self.update_week()
+
+    # --------------------------------------------------------------
+    def update_week(self, ref_date: date | None = None) -> None:
+        """Populate the widget with the week that contains ``ref_date``."""
+        if ref_date is None:
+            ref_date = date.today()
+        start = ref_date - timedelta(days=ref_date.weekday())
+        today = date.today()
+        day_initials = ["L", "M", "X", "J", "V", "S", "D"]
+
+        for i, (cell, day_lbl, num_lbl) in enumerate(self._cells):
+            d = start + timedelta(days=i)
+            day_lbl.setText(day_initials[i])
+            num_lbl.setText(str(d.day))
+            cell.setProperty("isToday", d == today)
+            num_lbl.setProperty("hasWorkout", d in self._workout_dates)
+            # Force style refresh
+            cell.style().unpolish(cell)
+            cell.style().polish(cell)
+

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -205,6 +205,7 @@ DailyPlanCard {
     border: 1px solid #4A5568;
     border-radius: 8px;
     padding: 10px;
+    qproperty-summaryIconColor: #A0AEC0;
 }
 
 QLabel#planTitle {
@@ -217,6 +218,10 @@ QLabel#planSubtitle {
     font-size: 9pt;
     color: #1A202C;
     padding: 1px 4px;
+}
+
+DailyPlanCard QLabel#planInfo {
+    color: #A0AEC0;
 }
 
 QProgressBar#dayProgress {
@@ -320,4 +325,33 @@ QPushButton#PrimaryCTAButton:hover {
 QWidget#GridContentContainer {
     border-top: 1px solid #4A5568;
     background-color: transparent;
+}
+
+/* Mini calendar styling */
+MiniCalendarWidget QWidget {
+    border-radius: 4px;
+    padding: 2px;
+}
+
+MiniCalendarWidget QWidget[isToday="true"] {
+    background-color: #2B6CB0;
+}
+
+MiniCalendarWidget QLabel#miniCalDayName {
+    font-size: 8pt;
+    color: #A0AEC0;
+}
+
+MiniCalendarWidget QLabel#miniCalDayNumber {
+    font-size: 9pt;
+    font-weight: bold;
+    color: #E2E8F0;
+}
+MiniCalendarWidget QLabel#miniCalDayNumber[hasWorkout="true"] {
+    color: #F6AD55;
+}
+
+DailyPlanCard[isRestDay="true"] {
+    background-color: #1E2530;
+    border: 1px dashed #4A5568;
 }

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -201,6 +201,7 @@ DailyPlanCard {
     border: 1px solid #CBD5E0;
     border-radius: 8px;
     padding: 10px;
+    qproperty-summaryIconColor: #4A5568;
 }
 
 QLabel#planTitle {
@@ -213,6 +214,10 @@ QLabel#planSubtitle {
     font-size: 9pt;
     color: #1A202C;
     padding: 1px 4px;
+}
+
+DailyPlanCard QLabel#planInfo {
+    color: #4A5568;
 }
 
 QProgressBar#dayProgress {
@@ -316,4 +321,32 @@ QPushButton#PrimaryCTAButton:hover {
 QWidget#GridContentContainer {
     border-top: 1px solid #4A5568;
     background-color: transparent;
+}
+
+MiniCalendarWidget QWidget {
+    border-radius: 4px;
+    padding: 2px;
+}
+
+MiniCalendarWidget QWidget[isToday="true"] {
+    background-color: #3182CE;
+}
+
+MiniCalendarWidget QLabel#miniCalDayName {
+    font-size: 8pt;
+    color: #4A5568;
+}
+
+MiniCalendarWidget QLabel#miniCalDayNumber {
+    font-size: 9pt;
+    font-weight: bold;
+    color: #2D3748;
+}
+MiniCalendarWidget QLabel#miniCalDayNumber[hasWorkout="true"] {
+    color: #D69E2E;
+}
+
+DailyPlanCard[isRestDay="true"] {
+    background-color: #F7FAFC;
+    border: 1px dashed #CBD5E0;
 }


### PR DESCRIPTION
## Summary
- add `MiniCalendarWidget` for week-at-a-glance
- refine `DailyPlanCard` to hide start button on rest days, recolor icons and mark rest days
- allow switching active plan and refresh the view
- integrate mini calendar and switch button into `PlansPage`
- tweak dark and light theme styles for new widgets
- **make plan cards interactive and allow activating newly generated plans**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e81a9b5b88320a036eacd2f9fc95f