### PR TITLE
Fix DB path and env typo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,5 +30,5 @@ dependencies:
     - matplotlib  # Para las gráficas en la GUI
     - streamlit   # Para la interfaz web
     - qtawesome
-    - pynstaller
+    - pyinstaller
     - pyqtgraph  # Para gráficos interactivos en la GUI

--- a/src/database.py
+++ b/src/database.py
@@ -8,7 +8,10 @@ logger = logging.getLogger(__name__)
 
 # --- Conexión a la Base de Datos ---
 def get_db_connection() -> sqlite3.Connection:
-    conn = sqlite3.connect("database.db")
+    """Devuelve una conexión a la base de datos utilizando la ruta global."""
+    from src.constants import DB_PATH
+
+    conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -206,5 +209,3 @@ def get_app_state(key: str) -> str | None:
     row = conn.execute("SELECT value FROM app_state WHERE key = ?", (key,)).fetchone()
     conn.close()
     return row["value"] if row else None
-
-# (He añadido todas las funciones que faltaban. Si aparece algún otro error, sería muy extraño)


### PR DESCRIPTION
## Summary
- fix typo in `environment.yml` for pyinstaller
- centralize database path using constant
- remove stray comment from `database.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e8a820ea0832095f9c52c101ff91a