### PR TITLE
Restore DailyPlanCard features

### DIFF
--- a/src/gui/widgets/daily_plan_card.py
+++ b/src/gui/widgets/daily_plan_card.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+from typing import Iterable
 from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -11,12 +11,15 @@ from PyQt5.QtWidgets import (
     QPushButton,
 )
 from PyQt5.QtCore import Qt, pyqtSignal
-from typing import Iterable
+from PyQt5.QtGui import QPalette
 import qtawesome as qta
+
+# Colores centralizados para los iconos
+ICON_COLORS = {"dark": "#A0AEC0", "light": "#4A5568"}
 
 
 class ExerciseRowWidget(QWidget):
-    """Fila individual de ejercicio en el plan diario."""
+    """Fila individual para un ejercicio en la tarjeta del plan."""
 
     checked = pyqtSignal(bool)
     clicked = pyqtSignal(str)
@@ -30,7 +33,7 @@ class ExerciseRowWidget(QWidget):
         layout.setSpacing(6)
 
         self.check_box = QCheckBox()
-        self.check_box.stateChanged.connect(self.on_checked)
+        self.check_box.stateChanged.connect(self._on_checked)
         layout.addWidget(self.check_box)
 
         self.check_lbl = QLabel()
@@ -42,6 +45,7 @@ class ExerciseRowWidget(QWidget):
         self.name_lbl.setObjectName("exerciseName")
         layout.addWidget(self.name_lbl)
         layout.addStretch(1)
+
         self.detail_lbl = QLabel(detail)
         self.detail_lbl.setObjectName("exerciseDetail")
         layout.addWidget(self.detail_lbl)
@@ -49,20 +53,20 @@ class ExerciseRowWidget(QWidget):
         self.opacity_effect = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self.opacity_effect)
 
-    # --------------------------------------------------
-    def on_checked(self, state: int) -> None:
+    def _on_checked(self, state: int) -> None:
         checked = state == Qt.Checked
         self.check_lbl.setVisible(checked)
         self.opacity_effect.setOpacity(0.4 if checked else 1.0)
         self.checked.emit(checked)
 
-    def mousePressEvent(self, event):  # pragma: no cover - UI interaction
-        self.clicked.emit(self.exercise_name)
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit(self.exercise_name)
         return super().mousePressEvent(event)
 
 
 class DailyPlanCard(QWidget):
-    """Tarjeta que muestra el plan diario de entrenamiento."""
+    """Tarjeta visual robusta para un plan diario, con gestión de tema autónoma."""
 
     exercise_clicked = pyqtSignal(str)
     start_clicked = pyqtSignal()
@@ -70,12 +74,14 @@ class DailyPlanCard(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("DailyPlanCard")
+        self.setProperty("isRestDay", False)
+
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(10, 10, 10, 10)
         main_layout.setSpacing(6)
 
         header_layout = QHBoxLayout()
-        self.title_lbl = QLabel("Plan para Hoy")
+        self.title_lbl = QLabel("...")
         self.title_lbl.setObjectName("planTitle")
         header_layout.addWidget(self.title_lbl)
         header_layout.addStretch(1)
@@ -84,21 +90,16 @@ class DailyPlanCard(QWidget):
         summary_layout.setContentsMargins(0, 0, 0, 0)
         summary_layout.setSpacing(4)
         self.count_icon_lbl = QLabel()
-        self.count_lbl = QLabel("")
+        self.count_lbl = QLabel()
         self.count_lbl.setObjectName("planInfo")
         summary_layout.addWidget(self.count_icon_lbl)
         summary_layout.addWidget(self.count_lbl)
         self.time_icon_lbl = QLabel()
-        self.time_lbl = QLabel("")
+        self.time_lbl = QLabel()
         self.time_lbl.setObjectName("planInfo")
         summary_layout.addWidget(self.time_icon_lbl)
         summary_layout.addWidget(self.time_lbl)
         header_layout.addLayout(summary_layout)
-
-        color = self.property("summaryIconColor") or "#A0AEC0"
-        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell", color=color).pixmap(14, 14))
-        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock", color=color).pixmap(14, 14))
-
         main_layout.addLayout(header_layout)
 
         self.progress_bar = QProgressBar()
@@ -113,7 +114,6 @@ class DailyPlanCard(QWidget):
 
         self.rest_label = QLabel("Descanso. No hay entrenamiento para hoy.")
         main_layout.addWidget(self.rest_label)
-        self.rest_label.hide()
 
         self.start_btn = QPushButton("Empezar Entrenamiento")
         self.start_btn.setObjectName("startTrainingButton")
@@ -123,47 +123,57 @@ class DailyPlanCard(QWidget):
         self._total_exercises = 0
         self._completed = 0
 
-    # --------------------------------------------------------------
+    def changeEvent(self, event) -> None:
+        """Se dispara cuando el estilo cambia, asegurando que los iconos se actualicen."""
+        super().changeEvent(event)
+        if event.type() == event.Type.StyleChange:
+            self._update_theme_dependent_styles()
+
+    def _update_theme_dependent_styles(self) -> None:
+        """Actualiza los iconos basándose en el color de fondo de la tarjeta."""
+        bg_color = self.palette().color(QPalette.Window)
+        is_dark_bg = (
+            0.299 * bg_color.red() + 0.587 * bg_color.green() + 0.114 * bg_color.blue()
+        ) < 128
+        icon_color = ICON_COLORS["dark"] if is_dark_bg else ICON_COLORS["light"]
+        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell", color=icon_color).pixmap(14, 14))
+        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock", color=icon_color).pixmap(14, 14))
+
     def update_plan(self, exercises: Iterable[tuple[str, str]]) -> None:
-        """Actualiza la lista de ejercicios mostrados."""
-        while self.exercises_layout.count():
-            item = self.exercises_layout.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
+        """Rellena la tarjeta con los datos de un día de entrenamiento."""
+        while item := self.exercises_layout.takeAt(0):
+            if widget := item.widget():
+                widget.deleteLater()
 
         exercises_list = list(exercises)
         has_exercises = bool(exercises_list)
+
         self.start_btn.setVisible(has_exercises)
         self.rest_label.setVisible(not has_exercises)
         self.setProperty("isRestDay", not has_exercises)
-        self.style().unpolish(self)
-        self.style().polish(self)
+
         if not has_exercises:
             self.count_lbl.setText("")
             self.time_lbl.setText("")
             self.progress_bar.setValue(0)
             self.start_btn.setEnabled(False)
-            return
+        else:
+            self.count_lbl.setText(f"{len(exercises_list)} ejercicios")
+            estimated = 5 + 5 * len(exercises_list)
+            self.time_lbl.setText(f"~{estimated} min")
+            self._total_exercises = len(exercises_list)
+            self._completed = 0
+            self.progress_bar.setValue(0)
+            for name, detail in exercises_list:
+                row = ExerciseRowWidget(name, detail)
+                row.checked.connect(self._on_row_checked)
+                row.clicked.connect(self.exercise_clicked)
+                self.exercises_layout.addWidget(row)
+            self.start_btn.setEnabled(True)
 
-        color = self.property("summaryIconColor") or "#A0AEC0"
-        self.count_icon_lbl.setPixmap(qta.icon("fa5s.dumbbell", color=color).pixmap(14, 14))
-        self.time_icon_lbl.setPixmap(qta.icon("fa5s.clock", color=color).pixmap(14, 14))
-
-        self.count_lbl.setText(f"{len(exercises_list)} ejercicios")
-        # Duración estimada simple: 5 min calentamiento + 5 min por ejercicio
-        estimated = 5 + 5 * len(exercises_list)
-        self.time_lbl.setText(f"{estimated} min")
-        self._total_exercises = len(exercises_list)
-        self._completed = 0
-        self.progress_bar.setValue(0)
-
-        for name, detail in exercises_list:
-            row = ExerciseRowWidget(name, detail)
-            row.checked.connect(self._on_row_checked)
-            row.clicked.connect(self.exercise_clicked)
-            self.exercises_layout.addWidget(row)
-
-        self.start_btn.setEnabled(True)
+        self.style().unpolish(self)
+        self.style().polish(self)
+        self._update_theme_dependent_styles()
 
     def _on_row_checked(self, checked: bool) -> None:
         if checked:

--- a/themes/dark.qss
+++ b/themes/dark.qss
@@ -205,7 +205,6 @@ DailyPlanCard {
     border: 1px solid #4A5568;
     border-radius: 8px;
     padding: 10px;
-    qproperty-summaryIconColor: #A0AEC0;
 }
 
 QLabel#planTitle {

--- a/themes/light.qss
+++ b/themes/light.qss
@@ -201,7 +201,6 @@ DailyPlanCard {
     border: 1px solid #CBD5E0;
     border-radius: 8px;
     padding: 10px;
-    qproperty-summaryIconColor: #4A5568;
 }
 
 QLabel#planTitle {


### PR DESCRIPTION
## Summary
- restore checklist and progress bar in `DailyPlanCard`
- keep theme-aware icon handling via palette introspection

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_685e89bb68fc832090c4e19406ed1056