### PR TITLE
Add default ordering comment for workouts

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -40,6 +40,7 @@ class Workout(models.Model):
         return f"Entrenamiento del {self.workout_date.strftime('%d-%m-%Y')}"
 
     class Meta:
+        # Order workouts by date descending (newest first)
         ordering = ['-workout_date']
 
 


### PR DESCRIPTION
## Summary
- ensure workouts API responds with newest dates first by clarifying ordering in `Workout` model

## Testing
- `python -m py_compile backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_685e9972f834832089ec0686c070f34b