### PR TITLE
Add FullCalendar frontend page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FullCalendar Demo</title>
+    <!-- FullCalendar CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+</head>
+<body>
+    <div id="calendar"></div>
+
+    <!-- FullCalendar JS -->
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var calendarEl = document.getElementById('calendar');
+
+            var calendar = new FullCalendar.Calendar(calendarEl, {
+                initialView: 'dayGridMonth',
+                events: function(fetchInfo, successCallback, failureCallback) {
+                    fetch('/api/workouts/')
+                        .then(function(response) { return response.json(); })
+                        .then(function(data) {
+                            var events = data.map(function(item) {
+                                var exerciseCount = item.entries ? item.entries.length : 0;
+                                var eventTitle = exerciseCount > 0 ? `${exerciseCount} Ejercicio(s)` : 'Día de Descanso';
+
+                                return {
+                                    title: eventTitle,
+                                    start: item.workout_date
+                                };
+                            });
+                            successCallback(events);
+                        })
+                        .catch(function(error) {
+                            console.error('Error fetching events:', error);
+                            failureCallback(error);
+                        });
+                }
+            });
+
+            calendar.render();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `frontend/index.html` implementing FullCalendar
- refine event titles to use number of exercises

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e9a9824f08320924ce8bdac9c0986