### PR TITLE
Add web calendar view to PyQt UI

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -34,6 +34,7 @@ from .pages import (
     ProgressPage,
     SettingsPage,
     ContactPage,
+    WebCalendarPage,
 )
 
 logger = logging.getLogger(__name__)
@@ -110,7 +111,10 @@ class MainWindow(QMainWindow):
         )
         self.progress_page = ProgressPage()
         self.results_panel = self.progress_page.results_panel
-        self.plans_page = PlansPage(self.translator)
+        calendar_html_path = os.path.join(
+            self.project_root, "frontend", "index.html"
+        )
+        self.plans_page = WebCalendarPage(os.path.abspath(calendar_html_path))
         self.plans_page.exercise_selected.connect(self._on_exercise_by_name)
         self.settings_page = SettingsPage(self._apply_theme)
         self.contact_page = ContactPage()

--- a/src/gui/pages/__init__.py
+++ b/src/gui/pages/__init__.py
@@ -6,6 +6,7 @@ from .settings_page import SettingsPage
 from .exercises_page import ExercisesPage
 from .exercise_detail_page import ExerciseDetailPage
 from .contact_page import ContactPage
+from .web_calendar_page import WebCalendarPage
 
 __all__ = [
     "DashboardPage",
@@ -16,5 +17,6 @@ __all__ = [
     "ExercisesPage",
     "ExerciseDetailPage",
     "ContactPage",
+    "WebCalendarPage",
 ]
 

--- a/src/gui/pages/web_calendar_page.py
+++ b/src/gui/pages/web_calendar_page.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtCore import QUrl
+import os
+
+
+class WebCalendarPage(QWidget):
+    """A page that displays a web-based component, like the FullCalendar."""
+
+    def __init__(self, html_file_path: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.browser = QWebEngineView()
+        url = QUrl.fromLocalFile(html_file_path)
+        self.browser.setUrl(url)
+
+        layout.addWidget(self.browser)


### PR DESCRIPTION
## Summary
- create `WebCalendarPage` with `QWebEngineView`
- expose `WebCalendarPage` via `pages` package
- integrate the new page into `MainWindow` replacing the Plans tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea499ccd083208dbb630e2944d671